### PR TITLE
Adjust smart click telemetry counts

### DIFF
--- a/packages/bytebot-ui/src/app/page.tsx
+++ b/packages/bytebot-ui/src/app/page.tsx
@@ -231,7 +231,9 @@ export default function Home() {
                     <div className="rounded bg-gray-50 px-2 py-1">Screens: <span className="font-medium">{telemetry.actionCounts?.["screenshot"] ?? 0}</span></div>
                   </div>
                   <div className="mt-1 grid grid-cols-3 gap-2 text-[11px] text-gray-700">
-                    <div className="rounded bg-indigo-50 px-2 py-1 text-indigo-700">Smart: <span className="font-medium">{telemetry.smartClicks ?? 0}</span></div>
+                    <div className="rounded bg-indigo-50 px-2 py-1 text-indigo-700" title="Successful smart click completions">
+                      Smart (completed): <span className="font-medium">{telemetry.smartClicks ?? 0}</span>
+                    </div>
                     <div className="rounded bg-sky-50 px-2 py-1 text-sky-700">Zooms: <span className="font-medium">{telemetry.progressiveZooms ?? 0}</span></div>
                     <div className="rounded bg-amber-50 px-2 py-1 text-amber-700">Retries: <span className="font-medium">{telemetry.retryClicks ?? 0}</span></div>
                   </div>

--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -267,7 +267,9 @@ export default function TaskPage() {
                   <div className="rounded bg-gray-50 px-2 py-1">Screens: <span className="font-medium">{telemetry.actionCounts?.["screenshot"] ?? 0}</span></div>
                 </div>
                 <div className="mt-1 grid grid-cols-3 gap-2 text-[11px] text-gray-700">
-                  <div className="rounded bg-indigo-50 px-2 py-1 text-indigo-700">Smart: <span className="font-medium">{telemetry.smartClicks ?? 0}</span></div>
+                  <div className="rounded bg-indigo-50 px-2 py-1 text-indigo-700" title="Successful smart click completions">
+                    Smart (completed): <span className="font-medium">{telemetry.smartClicks ?? 0}</span>
+                  </div>
                   <div className="rounded bg-sky-50 px-2 py-1 text-sky-700">Zooms: <span className="font-medium">{telemetry.progressiveZooms ?? 0}</span></div>
                   <div className="rounded bg-amber-50 px-2 py-1 text-amber-700">Retries: <span className="font-medium">{telemetry.retryClicks ?? 0}</span></div>
                 </div>
@@ -318,7 +320,7 @@ export default function TaskPage() {
                   </div>
                 )}
                 <div className="mt-1 grid grid-cols-2 gap-3 text-xs text-gray-600">
-                  <div>Smart clicks: {telemetry.smartClicks ?? 0}</div>
+                  <div>Smart clicks (completed): {telemetry.smartClicks ?? 0}</div>
                   <div>Prog. zooms: {telemetry.progressiveZooms ?? 0}</div>
                 </div>
                 {telemetry.hoverProbes && (

--- a/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
+++ b/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
@@ -66,7 +66,7 @@ export function TelemetryStatus({ className = "" }: Props) {
             Avg Δ: <span className="font-semibold">{data?.avgAbsDelta ?? "-"}</span>
           </span>
           <span>
-            Smart: <span className="font-semibold">{data?.smartClicks ?? 0}</span>
+            Smart (completed): <span className="font-semibold">{data?.smartClicks ?? 0}</span>
           </span>
           <span>
             Zooms: <span className="font-semibold">{data?.progressiveZooms ?? 0}</span>
@@ -149,7 +149,9 @@ export function TelemetryStatus({ className = "" }: Props) {
 
             {/* Chips row 2 */}
             <div className="mt-1 grid grid-cols-3 gap-2 text-[11px] text-gray-700">
-              <div className="rounded bg-indigo-50 px-2 py-1 text-indigo-700">Smart: <span className="font-medium">{data?.smartClicks ?? 0}</span></div>
+              <div className="rounded bg-indigo-50 px-2 py-1 text-indigo-700" title="Count of successful smart clicks">
+                Smart (completed): <span className="font-medium">{data?.smartClicks ?? 0}</span>
+              </div>
               <div className="rounded bg-sky-50 px-2 py-1 text-sky-700">Zooms: <span className="font-medium">{data?.progressiveZooms ?? 0}</span></div>
               <div className="rounded bg-amber-50 px-2 py-1 text-amber-700">Retries: <span className="font-medium">{data?.retryClicks ?? 0}</span></div>
             </div>

--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -101,7 +101,7 @@ export interface TelemetrySummary {
   retryClicks?: number;
   hoverProbes?: { count: number; avgDiff: number | null };
   postClickDiff?: { count: number; avgDiff: number | null };
-  smartClicks?: number;
+  smartClicks?: number; // Successful smart click completions
   progressiveZooms?: number;
 }
 

--- a/packages/bytebotd/src/telemetry/telemetry.controller.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.ts
@@ -81,7 +81,7 @@ export class TelemetryController {
             if (obj.name === 'screenshot_region' || obj.name === 'screenshot_custom_region') {
               progressiveZooms += 1;
             }
-          } else if (obj.type === 'smart_click' || obj.type === 'smart_click_complete') {
+          } else if (obj.type === 'smart_click_complete' && obj.success === true) {
             smartClicks += 1;
           } else if (obj.type === 'progressive_zoom') {
             progressiveZooms += 1;


### PR DESCRIPTION
## Summary
- count smart click telemetry only when a `smart_click_complete` event succeeds
- clarify UI smart click labels and tooltip to indicate the metric tracks completed attempts

## Testing
- npm run lint --prefix packages/bytebot-ui

------
https://chatgpt.com/codex/tasks/task_e_68cf2729df3c8323a8111e6257775b56