### PR TITLE
Tag progressive zoom telemetry source

### DIFF
--- a/packages/bytebot-agent/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.ts
@@ -25,6 +25,7 @@ import {
   isReadFileToolUseBlock,
   isScreenInfoToolUseBlock,
   ClickContext,
+  ActionSource,
 } from '@bytebot/shared';
 import { Logger } from '@nestjs/common';
 import OpenAI from 'openai';
@@ -652,6 +653,8 @@ function createSmartClickHelper(): SmartClickHelper | null {
     progressStep?: number;
     progressMessage?: string;
     progressTaskId?: string;
+    zoomLevel?: number;
+    source?: ActionSource;
   }) => {
     return screenshotRegion(options);
   };
@@ -662,6 +665,8 @@ function createSmartClickHelper(): SmartClickHelper | null {
     width: number;
     height: number;
     gridSize?: number;
+    zoomLevel?: number;
+    source?: ActionSource;
   }) => {
     return screenshotCustomRegion(options);
   };
@@ -1103,6 +1108,7 @@ async function screenshotRegion(input: {
   progressMessage?: string | null;
   progressTaskId?: string | null;
   zoomLevel?: number | null;
+  source?: ActionSource | null;
 }): Promise<{
   image: string;
   offset?: { x: number; y: number };
@@ -1126,6 +1132,7 @@ async function screenshotRegion(input: {
         progressMessage: input.progressMessage ?? undefined,
         progressTaskId: input.progressTaskId ?? undefined,
         zoomLevel: input.zoomLevel ?? undefined,
+        source: input.source ?? undefined,
       }),
     });
 
@@ -1163,6 +1170,7 @@ async function screenshotCustomRegion(input: {
   progressStep?: number | null;
   progressMessage?: string | null;
   progressTaskId?: string | null;
+  source?: ActionSource | null;
 }): Promise<{
   image: string;
   offset?: { x: number; y: number };
@@ -1189,6 +1197,7 @@ async function screenshotCustomRegion(input: {
         progressStep: input.progressStep ?? undefined,
         progressMessage: input.progressMessage ?? undefined,
         progressTaskId: input.progressTaskId ?? undefined,
+        source: input.source ?? undefined,
       }),
     });
 

--- a/packages/bytebot-agent/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent/src/agent/agent.tools.ts
@@ -354,6 +354,12 @@ export const _screenshotRegionTool = {
         description: 'Include global screen offset labels in the grid',
         nullable: true,
       },
+      source: {
+        type: 'string' as const,
+        enum: ['manual', 'smart_focus', 'progressive_zoom', 'binary_search'],
+        description: 'Optional telemetry source identifier for the capture',
+        nullable: true,
+      },
     },
     required: ['region'],
   },
@@ -385,6 +391,12 @@ export const _screenshotCustomRegionTool = {
       gridSize: {
         type: 'integer' as const,
         description: 'Optional grid size in pixels for the custom capture',
+        nullable: true,
+      },
+      source: {
+        type: 'string' as const,
+        enum: ['manual', 'smart_focus', 'progressive_zoom', 'binary_search'],
+        description: 'Optional telemetry source identifier for the capture',
         nullable: true,
       },
     },

--- a/packages/bytebot-agent/src/agent/progressive-zoom.helper.ts
+++ b/packages/bytebot-agent/src/agent/progressive-zoom.helper.ts
@@ -241,6 +241,7 @@ export class ProgressiveZoomHelper {
         height,
         gridSize: 25,
         zoomLevel,
+        source: 'progressive_zoom',
       },
     };
 

--- a/packages/bytebot-agent/src/agent/smart-click.helper.ts
+++ b/packages/bytebot-agent/src/agent/smart-click.helper.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ClickContext } from '@bytebot/shared';
+import { ActionSource, ClickContext } from '@bytebot/shared';
 
 export interface SmartClickAI {
   askAboutScreenshot(image: string, prompt: string): Promise<string>;
@@ -40,6 +40,7 @@ interface ScreenshotRegionOptions {
   progressMessage?: string;
   progressTaskId?: string;
   zoomLevel?: number;
+  source?: ActionSource;
 }
 
 interface ScreenshotCustomRegionOptions {
@@ -49,6 +50,7 @@ interface ScreenshotCustomRegionOptions {
   height: number;
   gridSize?: number;
   zoomLevel?: number;
+  source?: ActionSource;
 }
 
 interface ScreenshotTargetOptions {
@@ -181,6 +183,7 @@ export class SmartClickHelper {
         progressMessage: `Focused on region ${regionName}`,
         progressTaskId: this.currentTaskId,
         zoomLevel: 2.0,
+        source: 'progressive_zoom',
       });
       await this.emitTelemetryEvent('progressive_zoom', { region: regionName, zoom: 2.0 });
 
@@ -231,6 +234,7 @@ export class SmartClickHelper {
               h,
               25,
               3.0,
+              'progressive_zoom',
             );
             await this.emitTelemetryEvent('progressive_zoom', { region: 'custom', zoom: 3.0 });
 
@@ -423,6 +427,7 @@ export class SmartClickHelper {
     height: number,
     gridSize?: number,
     zoomLevel?: number,
+    source?: ActionSource,
   ): Promise<string> {
     const result = await this.screenshotCustomRegionFn({
       x,
@@ -431,6 +436,7 @@ export class SmartClickHelper {
       height,
       gridSize,
       zoomLevel,
+      source,
     });
 
     return result.image;

--- a/packages/bytebotd/src/computer-use/computer-use.service.ts
+++ b/packages/bytebotd/src/computer-use/computer-use.service.ts
@@ -214,7 +214,14 @@ export class ComputerUseService {
         }
 
         // Record progressive zoom event
-        await this.recordActionEvent('screenshot_custom_region');
+        const customRegionMetadata =
+          typeof action.source === 'string'
+            ? { source: action.source }
+            : undefined;
+        await this.recordActionEvent(
+          'screenshot_custom_region',
+          customRegionMetadata,
+        );
         return {
           image: base64,
           offset: customRegion.offset,
@@ -476,8 +483,12 @@ export class ComputerUseService {
   }
 
   // Record non-click actions for panel visibility
-  private async recordActionEvent(name: string): Promise<void> {
-    await this.telemetryService.recordEvent('action', { name });
+  private async recordActionEvent(
+    name: string,
+    metadata?: Record<string, any>,
+  ): Promise<void> {
+    const payload = metadata ? { name, ...metadata } : { name };
+    await this.telemetryService.recordEvent('action', payload);
   }
 
   private inferIntent(desc?: string): 'button' | 'link' | 'field' | 'icon' | 'menu' | 'unknown' {
@@ -732,7 +743,11 @@ export class ComputerUseService {
     }
 
     // Record progressive zoom event
-    await this.recordActionEvent('screenshot_region');
+    const regionMetadata =
+      typeof action.source === 'string'
+        ? { source: action.source }
+        : undefined;
+    await this.recordActionEvent('screenshot_region', regionMetadata);
 
     return {
       image: base64,

--- a/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
@@ -287,6 +287,10 @@ export class ScreenshotRegionFocusActionDto extends BaseActionDto {
   @IsOptional()
   @IsString()
   progressTaskId?: string;
+
+  @IsOptional()
+  @IsIn(Object.values(ClickSourceType))
+  source?: ClickSourceType;
 }
 
 export class ScreenshotCustomRegionActionDto extends BaseActionDto {
@@ -313,6 +317,10 @@ export class ScreenshotCustomRegionActionDto extends BaseActionDto {
   @IsNumber()
   @Min(5)
   gridSize?: number;
+
+  @IsOptional()
+  @IsIn(Object.values(ClickSourceType))
+  source?: ClickSourceType;
 }
 
 export class CursorPositionActionDto extends BaseActionDto {

--- a/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
@@ -1,0 +1,27 @@
+import { extractSource } from './telemetry.controller';
+
+describe('extractSource', () => {
+  it('returns undefined when no source metadata is present', () => {
+    expect(extractSource({ type: 'action', name: 'screenshot' })).toBeUndefined();
+    expect(extractSource(null)).toBeUndefined();
+  });
+
+  it('prefers explicit metadata fields when available', () => {
+    expect(extractSource({ source: 'progressive_zoom' })).toBe('progressive_zoom');
+    expect(
+      extractSource({ metadata: { source: 'progressive_zoom' } }),
+    ).toBe('progressive_zoom');
+    expect(
+      extractSource({ context: { source: 'progressive_zoom' } }),
+    ).toBe('progressive_zoom');
+  });
+
+  it('falls back to legacy progressive zoom entries without metadata', () => {
+    expect(
+      extractSource({ type: 'action', name: 'screenshot_region' }),
+    ).toBe('progressive_zoom');
+    expect(
+      extractSource({ type: 'progressive_zoom', message: 'zoomed' }),
+    ).toBe('progressive_zoom');
+  });
+});

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -32,11 +32,17 @@ export type ClickMouseAction = {
   context?: ClickContext;
 };
 
+export type ActionSource =
+  | "manual"
+  | "smart_focus"
+  | "progressive_zoom"
+  | "binary_search";
+
 export type ClickContext = {
   region?: { x: number; y: number; width: number; height: number };
   zoomLevel?: number;
   targetDescription?: string;
-  source?: "manual" | "smart_focus" | "progressive_zoom" | "binary_search";
+  source?: ActionSource;
   clickTaskId?: string;
 };
 
@@ -125,6 +131,7 @@ export type ScreenshotRegionAction = {
   progressStep?: number;
   progressMessage?: string;
   progressTaskId?: string;
+  source?: ActionSource;
 };
 
 export type ScreenshotCustomRegionAction = {
@@ -145,6 +152,7 @@ export type ScreenshotCustomRegionAction = {
   progressStep?: number;
   progressMessage?: string;
   progressTaskId?: string;
+  source?: ActionSource;
 };
 
 export type CursorPositionAction = {

--- a/packages/shared/src/types/messageContent.types.ts
+++ b/packages/shared/src/types/messageContent.types.ts
@@ -1,4 +1,10 @@
-import { Button, Coordinates, Press, ClickContext } from "./computerAction.types";
+import {
+  Button,
+  Coordinates,
+  Press,
+  ClickContext,
+  ActionSource,
+} from "./computerAction.types";
 
 // Content block types
 export enum MessageContentType {
@@ -192,6 +198,7 @@ export type ScreenshotRegionToolUseBlock = ToolUseContentBlock & {
     progressStep?: number;
     progressMessage?: string;
     progressTaskId?: string;
+    source?: ActionSource;
   };
 };
 
@@ -203,6 +210,7 @@ export type ScreenshotCustomRegionToolUseBlock = ToolUseContentBlock & {
     width: number;
     height: number;
     gridSize?: number;
+    source?: ActionSource;
   };
 };
 


### PR DESCRIPTION
## Summary
- add an ActionSource helper type and allow screenshot actions/tool blocks to include telemetry metadata
- propagate progressive zoom source markers from the agent helpers through to the desktop service action logger
- expose an extractSource utility in the telemetry controller with tests to recognise progressive zoom entries in new and historic logs

## Testing
- npm run build --prefix packages/shared
- npm test --prefix packages/bytebotd

------
https://chatgpt.com/codex/tasks/task_e_68cf2e384f788323a2d76f9037216759