### PR TITLE
Include screenshot source metadata in tool use blocks

### DIFF
--- a/packages/bytebot-agent/src/__tests__/computerAction.utils.spec.ts
+++ b/packages/bytebot-agent/src/__tests__/computerAction.utils.spec.ts
@@ -1,0 +1,70 @@
+import {
+  convertScreenshotRegionActionToToolUseBlock,
+  convertScreenshotCustomRegionActionToToolUseBlock,
+} from '../../../shared/src/utils/computerAction.utils';
+import {
+  ScreenshotRegionAction,
+  ScreenshotCustomRegionAction,
+} from '../../../shared/src/types/computerAction.types';
+
+describe('screenshot action converters', () => {
+  it('includes source when present for screenshot region actions', () => {
+    const actionWithSource: ScreenshotRegionAction = {
+      action: 'screenshot_region',
+      region: 'middle-center',
+      source: 'progressive_zoom',
+    };
+
+    const block = convertScreenshotRegionActionToToolUseBlock(
+      actionWithSource,
+      'test-id'
+    );
+
+    expect(block.input).toHaveProperty('source', 'progressive_zoom');
+
+    const actionWithoutSource: ScreenshotRegionAction = {
+      action: 'screenshot_region',
+      region: 'middle-center',
+    };
+
+    const blockWithoutSource = convertScreenshotRegionActionToToolUseBlock(
+      actionWithoutSource,
+      'test-id-2'
+    );
+
+    expect(blockWithoutSource.input).not.toHaveProperty('source');
+  });
+
+  it('includes source when present for screenshot custom region actions', () => {
+    const actionWithSource: ScreenshotCustomRegionAction = {
+      action: 'screenshot_custom_region',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      source: 'smart_focus',
+    };
+
+    const block = convertScreenshotCustomRegionActionToToolUseBlock(
+      actionWithSource,
+      'custom-id'
+    );
+
+    expect(block.input).toHaveProperty('source', 'smart_focus');
+
+    const actionWithoutSource: ScreenshotCustomRegionAction = {
+      action: 'screenshot_custom_region',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    };
+
+    const blockWithoutSource = convertScreenshotCustomRegionActionToToolUseBlock(
+      actionWithoutSource,
+      'custom-id-2'
+    );
+
+    expect(blockWithoutSource.input).not.toHaveProperty('source');
+  });
+});

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -32,11 +32,17 @@ export type ClickMouseAction = {
   context?: ClickContext;
 };
 
+export type ActionSource =
+  | "manual"
+  | "smart_focus"
+  | "progressive_zoom"
+  | "binary_search";
+
 export type ClickContext = {
   region?: { x: number; y: number; width: number; height: number };
   zoomLevel?: number;
   targetDescription?: string;
-  source?: "manual" | "smart_focus" | "progressive_zoom" | "binary_search";
+  source?: ActionSource;
   clickTaskId?: string;
 };
 
@@ -125,6 +131,7 @@ export type ScreenshotRegionAction = {
   progressStep?: number;
   progressMessage?: string;
   progressTaskId?: string;
+  source?: ActionSource;
 };
 
 export type ScreenshotCustomRegionAction = {
@@ -145,6 +152,7 @@ export type ScreenshotCustomRegionAction = {
   progressStep?: number;
   progressMessage?: string;
   progressTaskId?: string;
+  source?: ActionSource;
 };
 
 export type CursorPositionAction = {

--- a/packages/shared/src/utils/computerAction.utils.ts
+++ b/packages/shared/src/utils/computerAction.utils.ts
@@ -354,6 +354,7 @@ export function convertScreenshotRegionActionToToolUseBlock(
           "progressTaskId",
           action.progressTaskId,
         ],
+        [typeof action.source === "string", "source", action.source],
       ]
     )
   );
@@ -376,6 +377,7 @@ export function convertScreenshotCustomRegionActionToToolUseBlock(
       [
         [typeof action.gridSize === "number", "gridSize", action.gridSize],
         [typeof action.zoomLevel === "number", "zoomLevel", action.zoomLevel],
+        [typeof action.source === "string", "source", action.source],
       ]
     )
   );


### PR DESCRIPTION
## Summary
- allow screenshot region converter to forward source metadata when present
- extend shared screenshot action types with reusable ActionSource union
- add Jest coverage ensuring screenshot converters include or omit source appropriately

## Testing
- npm run build --prefix packages/shared
- npm run test --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68cf3271d2948323ad60ca78c4eeb91a