### PR TITLE
Handle newline typing in nut service

### DIFF
--- a/packages/bytebotd/src/nut/nut.service.spec.ts
+++ b/packages/bytebotd/src/nut/nut.service.spec.ts
@@ -1,0 +1,73 @@
+jest.mock('@nut-tree-fork/nut-js', () => {
+  const pressKeyMock = jest.fn().mockResolvedValue(undefined);
+  const releaseKeyMock = jest.fn().mockResolvedValue(undefined);
+
+  return {
+    keyboard: {
+      config: { autoDelayMs: 0 },
+      pressKey: pressKeyMock,
+      releaseKey: releaseKeyMock,
+    },
+    mouse: {
+      config: { autoDelayMs: 0 },
+      click: jest.fn(),
+      setPosition: jest.fn(),
+    },
+    screen: {},
+    Point: class {},
+    Key: {
+      Enter: 'Enter',
+      LeftShift: 'LeftShift',
+    },
+    Button: {},
+    FileType: {},
+  };
+});
+
+import { NutService } from './nut.service';
+import { Key, keyboard } from '@nut-tree-fork/nut-js';
+
+type MockedKeyboard = {
+  config: { autoDelayMs: number };
+  pressKey: jest.Mock<Promise<void>, any>;
+  releaseKey: jest.Mock<Promise<void>, any>;
+};
+
+const keyboardMock = keyboard as unknown as MockedKeyboard;
+
+describe('NutService', () => {
+  let service: NutService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new NutService();
+  });
+
+  it("maps a newline character to the Enter key", () => {
+    const keyInfo = (service as any).charToKeyInfo('\n');
+    expect(keyInfo).toEqual({ keyCode: Key.Enter, withShift: false });
+  });
+
+  it('maps a carriage return character to the Enter key', () => {
+    const keyInfo = (service as any).charToKeyInfo('\r');
+    expect(keyInfo).toEqual({ keyCode: Key.Enter, withShift: false });
+  });
+
+  it('presses Enter when typing a newline', async () => {
+    await service.typeText('\n');
+
+    expect(keyboardMock.pressKey).toHaveBeenCalledTimes(1);
+    expect(keyboardMock.pressKey).toHaveBeenCalledWith(Key.Enter);
+    expect(keyboardMock.releaseKey).toHaveBeenCalledTimes(1);
+    expect(keyboardMock.releaseKey).toHaveBeenCalledWith(Key.Enter);
+  });
+
+  it('types Windows-style newlines only once', async () => {
+    await service.typeText('\r\n');
+
+    expect(keyboardMock.pressKey).toHaveBeenCalledTimes(1);
+    expect(keyboardMock.pressKey).toHaveBeenCalledWith(Key.Enter);
+    expect(keyboardMock.releaseKey).toHaveBeenCalledTimes(1);
+    expect(keyboardMock.releaseKey).toHaveBeenCalledWith(Key.Enter);
+  });
+});

--- a/packages/bytebotd/src/nut/nut.service.ts
+++ b/packages/bytebotd/src/nut/nut.service.ts
@@ -221,6 +221,10 @@ export class NutService {
     try {
       for (let i = 0; i < text.length; i++) {
         const char = text[i];
+
+        if (char === '\r' && text[i + 1] === '\n') {
+          continue;
+        }
         const keyInfo = this.charToKeyInfo(char);
         if (keyInfo) {
           if (keyInfo.withShift) {
@@ -303,6 +307,8 @@ export class NutService {
     }
 
     // Handle special characters
+    const newlineChar = '\n';
+    const carriageReturnChar = '\r';
     const specialCharMap: Record<string, { keyCode: Key; withShift: boolean }> =
       {
         ' ': { keyCode: Key.Space, withShift: false },
@@ -340,7 +346,8 @@ export class NutService {
         '>': { keyCode: Key.Period, withShift: true },
         '?': { keyCode: Key.Slash, withShift: true },
         '~': { keyCode: Key.Grave, withShift: true },
-        '\n': { keyCode: Key.Enter, withShift: false },
+        [newlineChar]: { keyCode: Key.Enter, withShift: false },
+        [carriageReturnChar]: { keyCode: Key.Enter, withShift: false },
       };
 
     return specialCharMap[char] || null;


### PR DESCRIPTION
## Summary
- ensure `typeText` skips duplicate presses for carriage-return/newline sequences and map both newline and carriage return to Enter
- add focused tests validating newline mappings and Enter key presses

## Testing
- npm test --prefix packages/bytebotd

------
https://chatgpt.com/codex/tasks/task_e_68cf372d42dc8323ae455d5f26956bff