### PR TITLE
Handle orphaned tool calls in proxy sanitizer

### DIFF
--- a/packages/bytebot-agent/src/proxy/proxy.service.spec.ts
+++ b/packages/bytebot-agent/src/proxy/proxy.service.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+  APIUserAbortError: class {},
+}));
+
+jest.mock(
+  '@bytebot/shared',
+  () => ({
+    MessageContentType: {
+      Text: 'text',
+      ToolUse: 'tool_use',
+      ToolResult: 'tool_result',
+      Image: 'image',
+      Thinking: 'thinking',
+    },
+    isUserActionContentBlock: jest.fn().mockReturnValue(false),
+    isComputerToolUseContentBlock: jest.fn().mockReturnValue(false),
+    isImageContentBlock: jest.fn().mockReturnValue(false),
+  }),
+  { virtual: true },
+);
+
+import { ConfigService } from '@nestjs/config';
+import { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { ProxyService } from './proxy.service';
+
+describe('ProxyService sanitizeChatMessages', () => {
+  const createService = () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('http://localhost'),
+    } as unknown as ConfigService;
+    return new ProxyService(configService);
+  };
+
+  it('removes unresolved tool calls when user message follows', () => {
+    const service = createService();
+
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: 'assistant',
+        content: 'Working...',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'doSomething',
+              arguments: '{}',
+            },
+          },
+        ],
+      } as any,
+      {
+        role: 'user',
+        content: 'Next step',
+      },
+    ];
+
+    const sanitized = (service as any).sanitizeChatMessages(messages);
+
+    expect(sanitized).toHaveLength(2);
+    expect((sanitized[0] as any).tool_calls).toBeUndefined();
+
+    const serializedContent =
+      typeof sanitized[0].content === 'string'
+        ? sanitized[0].content
+        : JSON.stringify(sanitized[0].content);
+
+    expect(serializedContent).toContain('[tool-call:doSomething] unresolved');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure proxy sanitizeChatMessages downgrades unresolved tool calls instead of leaving them pending
- add a regression test covering assistant tool calls followed by user input

## Testing
- npm run build --prefix packages/shared
- CI=true npm test --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68cf3a50dae48323b7fbc82e01108e14