### PR TITLE
Add optional button titles to accuracy panel

### DIFF
--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -221,6 +221,8 @@ export default function TaskPage() {
               onRefresh={refreshTelemetry}
               onReset={resetTelemetry}
               className="mb-3"
+              refreshTitle="Refresh"
+              resetTitle="Reset accuracy stats"
             />
             {/* Messages scrollable area */}
             <div

--- a/packages/bytebot-ui/src/components/telemetry/AccuracyPanel.tsx
+++ b/packages/bytebot-ui/src/components/telemetry/AccuracyPanel.tsx
@@ -7,6 +7,8 @@ interface AccuracyPanelProps {
   onRefresh: () => void;
   onReset: () => void;
   className?: string;
+  refreshTitle?: string;
+  resetTitle?: string;
 }
 
 export const AccuracyPanel: React.FC<AccuracyPanelProps> = ({
@@ -14,6 +16,8 @@ export const AccuracyPanel: React.FC<AccuracyPanelProps> = ({
   onRefresh,
   onReset,
   className,
+  refreshTitle = undefined,
+  resetTitle = undefined,
 }) => {
   if (!telemetry) {
     return null;
@@ -45,12 +49,14 @@ export const AccuracyPanel: React.FC<AccuracyPanelProps> = ({
           <button
             className="rounded border px-2 py-0.5 text-[11px] text-gray-700 hover:bg-gray-50"
             onClick={onRefresh}
+            title={refreshTitle}
           >
             Refresh
           </button>
           <button
             className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-700 hover:bg-red-100"
             onClick={onReset}
+            title={resetTitle}
           >
             Reset
           </button>


### PR DESCRIPTION
## Summary
- allow the accuracy panel to accept optional refresh/reset tooltip titles
- wire the task page to provide the previous refresh and reset tooltips

## Testing
- npm run format *(fails: no package.json at repo root)*

------
https://chatgpt.com/codex/tasks/task_e_68cf448860708323990a08999231ca46