### PR TITLE
Remove telemetry widget from home page

### DIFF
--- a/packages/bytebot-ui/src/app/page.tsx
+++ b/packages/bytebot-ui/src/app/page.tsx
@@ -9,7 +9,6 @@ import { startTask } from "@/utils/taskUtils";
 import { Model } from "@/types";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { TaskList } from "@/components/tasks/TaskList";
-import { TelemetryStatus } from "@/components/telemetry/TelemetryStatus";
 
 interface StockPhotoProps {
   src: string;
@@ -179,7 +178,6 @@ export default function Home() {
                 </div>
               </div>
 
-              <TelemetryStatus className="mb-3 w-full" />
               <TaskList
                 className="w-full"
                 title="Latest Tasks"


### PR DESCRIPTION
## Summary
- remove the telemetry status widget from the home page layout now that the task view owns it

## Testing
- npm run lint --prefix packages/bytebot-ui

------
https://chatgpt.com/codex/tasks/task_e_68cf48e642508323805a1e874e5945a2