### PR TITLE
Support telemetry session selection across stack

### DIFF
--- a/packages/bytebot-agent/src/tasks/tasks.controller.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.ts
@@ -114,23 +114,34 @@ export class TasksController {
   async telemetrySummary(
     @Query('app') app?: string,
     @Query('limit') limit?: string,
+    @Query('session') session?: string,
   ) {
     const base = process.env.BYTEBOT_DESKTOP_BASE_URL;
     if (!base) {
-      throw new HttpException('Desktop base URL not configured', HttpStatus.BAD_GATEWAY);
+      throw new HttpException(
+        'Desktop base URL not configured',
+        HttpStatus.BAD_GATEWAY,
+      );
     }
     const qs: string[] = [];
     if (app) qs.push(`app=${encodeURIComponent(app)}`);
     if (limit) qs.push(`limit=${encodeURIComponent(limit)}`);
+    if (session) qs.push(`session=${encodeURIComponent(session)}`);
     const url = `${base}/telemetry/summary${qs.length ? `?${qs.join('&')}` : ''}`;
     try {
       const res = await fetch(url);
       if (!res.ok) {
-        throw new HttpException(`Failed to fetch telemetry: ${res.statusText}`, HttpStatus.BAD_GATEWAY);
+        throw new HttpException(
+          `Failed to fetch telemetry: ${res.statusText}`,
+          HttpStatus.BAD_GATEWAY,
+        );
       }
       return await res.json();
     } catch (e: any) {
-      throw new HttpException(`Error fetching telemetry: ${e.message}`, HttpStatus.BAD_GATEWAY);
+      throw new HttpException(
+        `Error fetching telemetry: ${e.message}`,
+        HttpStatus.BAD_GATEWAY,
+      );
     }
   }
 
@@ -138,41 +149,90 @@ export class TasksController {
   async telemetryApps(
     @Query('limit') limit?: string,
     @Query('window') window?: string,
+    @Query('session') session?: string,
   ) {
     const base = process.env.BYTEBOT_DESKTOP_BASE_URL;
     if (!base) {
-      throw new HttpException('Desktop base URL not configured', HttpStatus.BAD_GATEWAY);
+      throw new HttpException(
+        'Desktop base URL not configured',
+        HttpStatus.BAD_GATEWAY,
+      );
     }
     const qs: string[] = [];
     if (limit) qs.push(`limit=${encodeURIComponent(limit)}`);
     if (window) qs.push(`window=${encodeURIComponent(window)}`);
+    if (session) qs.push(`session=${encodeURIComponent(session)}`);
     const url = `${base}/telemetry/apps${qs.length ? `?${qs.join('&')}` : ''}`;
     try {
       const res = await fetch(url);
       if (!res.ok) {
-        throw new HttpException(`Failed to fetch apps: ${res.statusText}`, HttpStatus.BAD_GATEWAY);
+        throw new HttpException(
+          `Failed to fetch apps: ${res.statusText}`,
+          HttpStatus.BAD_GATEWAY,
+        );
       }
       return await res.json();
     } catch (e: any) {
-      throw new HttpException(`Error fetching apps: ${e.message}`, HttpStatus.BAD_GATEWAY);
+      throw new HttpException(
+        `Error fetching apps: ${e.message}`,
+        HttpStatus.BAD_GATEWAY,
+      );
     }
   }
 
   @Post('telemetry/reset')
-  async telemetryReset() {
+  async telemetryReset(@Query('session') session?: string) {
     const base = process.env.BYTEBOT_DESKTOP_BASE_URL;
     if (!base) {
-      throw new HttpException('Desktop base URL not configured', HttpStatus.BAD_GATEWAY);
+      throw new HttpException(
+        'Desktop base URL not configured',
+        HttpStatus.BAD_GATEWAY,
+      );
     }
-    const url = `${base}/telemetry/reset`;
+    const url = `${base}/telemetry/reset${
+      session ? `?session=${encodeURIComponent(session)}` : ''
+    }`;
     try {
       const res = await fetch(url, { method: 'POST' });
       if (!res.ok) {
-        throw new HttpException(`Failed to reset telemetry: ${res.statusText}`, HttpStatus.BAD_GATEWAY);
+        throw new HttpException(
+          `Failed to reset telemetry: ${res.statusText}`,
+          HttpStatus.BAD_GATEWAY,
+        );
       }
       return await res.json();
     } catch (e: any) {
-      throw new HttpException(`Error resetting telemetry: ${e.message}`, HttpStatus.BAD_GATEWAY);
+      throw new HttpException(
+        `Error resetting telemetry: ${e.message}`,
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+  }
+
+  @Get('telemetry/sessions')
+  async telemetrySessions() {
+    const base = process.env.BYTEBOT_DESKTOP_BASE_URL;
+    if (!base) {
+      throw new HttpException(
+        'Desktop base URL not configured',
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+    const url = `${base}/telemetry/sessions`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new HttpException(
+          `Failed to fetch sessions: ${res.statusText}`,
+          HttpStatus.BAD_GATEWAY,
+        );
+      }
+      return await res.json();
+    } catch (e: any) {
+      throw new HttpException(
+        `Error fetching sessions: ${e.message}`,
+        HttpStatus.BAD_GATEWAY,
+      );
     }
   }
 

--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -108,3 +108,7 @@ export interface TelemetrySummary {
 export interface TelemetryApps {
   apps: Array<{ name: string; count: number }>;
 }
+
+export interface TelemetrySessions {
+  sessions: string[];
+}


### PR DESCRIPTION
## Summary
- scope telemetry storage by session in the desktop daemon and expose helpers to switch, enumerate, and reset per-session data
- allow telemetry summary/apps endpoints to accept an optional session and surface the list of sessions through the daemon and API proxy
- update the UI to fetch available telemetry sessions, let the operator pick one, and include that value when requesting summaries or resets

## Testing
- `npm run lint --prefix packages/bytebotd` *(fails: existing lint issues in unrelated files)*
- `npm run lint --prefix packages/bytebot-agent` *(fails: existing lint issues in unrelated files)*
- `npm run lint --prefix packages/bytebot-ui`

------
https://chatgpt.com/codex/tasks/task_e_68cf4bbcf658832382c3bfe73120666b