### PR TITLE
Add API key settings dialog to header

### DIFF
--- a/packages/bytebot-ui/src/components/layout/Header.tsx
+++ b/packages/bytebot-ui/src/components/layout/Header.tsx
@@ -9,12 +9,17 @@ import {
   TaskDaily01Icon,
   Home01Icon,
   ComputerIcon,
+  Settings01Icon,
 } from "@hugeicons/core-free-icons";
 import { usePathname } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { ApiKeySettingsDialog } from "@/components/settings/ApiKeySettingsDialog";
 
 export function Header() {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const pathname = usePathname();
 
   // After mounting, we can safely show the theme-dependent content
@@ -88,7 +93,18 @@ export function Header() {
           </Link>
         </div>
       </div>
-      <div className="flex items-center gap-3"></div>
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => setSettingsOpen(true)}
+          aria-label="Open API key settings"
+        >
+          <HugeiconsIcon icon={Settings01Icon} className="h-5 w-5" />
+        </Button>
+        <ApiKeySettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+      </div>
     </header>
   );
 }

--- a/packages/bytebot-ui/src/components/settings/ApiKeySettingsDialog.tsx
+++ b/packages/bytebot-ui/src/components/settings/ApiKeySettingsDialog.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import * as Dialog from "@radix-ui/react-dialog"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { CloseCircleIcon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+import {
+  type ApiKeyMetadataMap,
+  type ApiKeyName,
+  fetchApiKeyMetadata,
+  updateApiKeys,
+} from "@/utils/settingsUtils"
+
+const API_KEY_FIELDS: { name: ApiKeyName; label: string; description: string }[] = [
+  {
+    name: "ANTHROPIC_API_KEY",
+    label: "Anthropic API Key",
+    description: "Used for Claude-based Bytebot agents.",
+  },
+  {
+    name: "OPENAI_API_KEY",
+    label: "OpenAI API Key",
+    description: "Enables GPT models inside Bytebot.",
+  },
+  {
+    name: "GEMINI_API_KEY",
+    label: "Gemini API Key",
+    description: "Needed for Google Gemini integrations.",
+  },
+  {
+    name: "OPENROUTER_API_KEY",
+    label: "OpenRouter API Key",
+    description: "Allows routing requests through OpenRouter.",
+  },
+]
+
+export interface ApiKeySettingsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ApiKeySettingsDialog({
+  open,
+  onOpenChange,
+}: ApiKeySettingsDialogProps) {
+  const [metadata, setMetadata] = useState<ApiKeyMetadataMap | null>(null)
+  const [formValues, setFormValues] = useState<Record<ApiKeyName, string>>({
+    ANTHROPIC_API_KEY: "",
+    OPENAI_API_KEY: "",
+    GEMINI_API_KEY: "",
+    OPENROUTER_API_KEY: "",
+  })
+  const [loading, setLoading] = useState(false)
+  const [fetching, setFetching] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    let isMounted = true
+
+    async function loadMetadata() {
+      setFetching(true)
+      setError(null)
+      setSuccess(null)
+
+      const data = await fetchApiKeyMetadata()
+
+      if (isMounted) {
+        setMetadata(data)
+        setFetching(false)
+        setFormValues({
+          ANTHROPIC_API_KEY: "",
+          OPENAI_API_KEY: "",
+          GEMINI_API_KEY: "",
+          OPENROUTER_API_KEY: "",
+        })
+      }
+    }
+
+    void loadMetadata()
+
+    return () => {
+      isMounted = false
+    }
+  }, [open])
+
+  const placeholderByKey = useMemo(() => {
+    if (!metadata) return {}
+
+    return Object.fromEntries(
+      API_KEY_FIELDS.map(({ name }) => {
+        const meta = metadata[name]
+
+        if (!meta?.configured) {
+          return [name, ""]
+        }
+
+        const lengthText = meta.length ? `${meta.length} chars` : "Configured"
+        const suffix = meta.lastFour ? `••••${meta.lastFour}` : null
+        return [name, suffix ? `${lengthText} (${suffix})` : lengthText]
+      })
+    ) as Partial<Record<ApiKeyName, string>>
+  }, [metadata])
+
+  function handleChange(key: ApiKeyName, value: string) {
+    setFormValues((prev) => ({
+      ...prev,
+      [key]: value,
+    }))
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    setError(null)
+    setSuccess(null)
+
+    const payloadEntries = Object.entries(formValues).filter(([, value]) => value.trim().length > 0) as [
+      ApiKeyName,
+      string,
+    ][]
+
+    if (payloadEntries.length === 0) {
+      setError("Enter at least one API key to update.")
+      return
+    }
+
+    setLoading(true)
+
+    const payload = Object.fromEntries(payloadEntries)
+    const ok = await updateApiKeys(payload)
+
+    if (!ok) {
+      setError("Unable to save API keys. Please try again.")
+      setLoading(false)
+      return
+    }
+
+    setSuccess("API keys saved successfully.")
+    setLoading(false)
+    setFormValues({
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      GEMINI_API_KEY: "",
+      OPENROUTER_API_KEY: "",
+    })
+
+    const data = await fetchApiKeyMetadata()
+    setMetadata(data)
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-bytebot-bronze-light-7 bg-background p-6 shadow-2xl focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=open]:zoom-in-95 data-[state=closed]:fade-out data-[state=closed]:zoom-out-95",
+          )}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <Dialog.Title className="text-lg font-semibold">API Keys</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground">
+                Securely store provider keys. Leave fields blank to keep existing values.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Close"
+                className="text-muted-foreground transition hover:text-foreground"
+              >
+                <HugeiconsIcon icon={CloseCircleIcon} className="h-6 w-6" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+            {API_KEY_FIELDS.map(({ name, label, description }) => (
+              <div key={name} className="space-y-2">
+                <Label htmlFor={name}>{label}</Label>
+                <Input
+                  id={name}
+                  type="password"
+                  placeholder={placeholderByKey[name] ?? ""}
+                  autoComplete="off"
+                  value={formValues[name] ?? ""}
+                  onChange={(event) => handleChange(name, event.target.value)}
+                  disabled={loading}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {description}
+                  {metadata?.[name]?.configured && !formValues[name] && !fetching && (
+                    <span className="ml-1 text-foreground">
+                      Configured
+                      {metadata?.[name]?.length
+                        ? ` • ${metadata?.[name]?.length} characters`
+                        : ""}
+                    </span>
+                  )}
+                </p>
+              </div>
+            ))}
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            {success && <p className="text-sm text-emerald-600">{success}</p>}
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <Dialog.Close asChild>
+                <Button type="button" variant="ghost" disabled={loading}>
+                  Cancel
+                </Button>
+              </Dialog.Close>
+              <Button type="submit" disabled={loading}>
+                {loading ? "Saving..." : "Save keys"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/packages/bytebot-ui/src/utils/settingsUtils.ts
+++ b/packages/bytebot-ui/src/utils/settingsUtils.ts
@@ -1,0 +1,94 @@
+export type ApiKeyName =
+  | "ANTHROPIC_API_KEY"
+  | "OPENAI_API_KEY"
+  | "GEMINI_API_KEY"
+  | "OPENROUTER_API_KEY"
+
+export interface ApiKeyMetadata {
+  name: ApiKeyName
+  configured: boolean
+  length?: number
+  lastFour?: string
+  updatedAt?: string
+}
+
+export type ApiKeyMetadataMap = Record<ApiKeyName, ApiKeyMetadata | undefined>
+
+const API_CONFIG = {
+  baseUrl: "/api",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  credentials: "include" as RequestCredentials,
+}
+
+type ApiKeyResponse = {
+  keys: Record<
+    ApiKeyName,
+    {
+      configured: boolean
+      length?: number
+      lastFour?: string
+      updatedAt?: string
+    }
+  >
+}
+
+export async function fetchApiKeyMetadata(): Promise<ApiKeyMetadataMap | null> {
+  try {
+    const response = await fetch(`${API_CONFIG.baseUrl}/settings/keys`, {
+      method: "GET",
+      headers: API_CONFIG.headers,
+      credentials: API_CONFIG.credentials,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch API keys: ${response.status}`)
+    }
+
+    const data: ApiKeyResponse = await response.json()
+
+    return Object.entries(data.keys).reduce<ApiKeyMetadataMap>((acc, [key, value]) => {
+      const name = key as ApiKeyName
+      acc[name] = {
+        name,
+        configured: Boolean(value?.configured),
+        length: value?.length,
+        lastFour: value?.lastFour,
+        updatedAt: value?.updatedAt,
+      }
+      return acc
+    }, {
+      ANTHROPIC_API_KEY: undefined,
+      OPENAI_API_KEY: undefined,
+      GEMINI_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+    })
+  } catch (error) {
+    console.error("Error fetching API key metadata", error)
+    return null
+  }
+}
+
+type ApiKeyUpdatePayload = Partial<Record<ApiKeyName, string>>
+
+export async function updateApiKeys(payload: ApiKeyUpdatePayload): Promise<boolean> {
+  try {
+    const response = await fetch(`${API_CONFIG.baseUrl}/settings/keys`, {
+      method: "POST",
+      headers: API_CONFIG.headers,
+      credentials: API_CONFIG.credentials,
+      body: JSON.stringify(payload),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.text()
+      throw new Error(`Failed to update API keys: ${response.status} ${errorBody}`)
+    }
+
+    return true
+  } catch (error) {
+    console.error("Error updating API keys", error)
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- add a client-side API key settings dialog with secure inputs and Radix dialog primitives
- implement settings utilities to read and update API key metadata through the API proxy
- surface the dialog from the header with a gear button for easy access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf4fa37cd4832388339da835c8f50d