### PR TITLE
Expose current telemetry session metadata across stack

### DIFF
--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -110,5 +110,6 @@ export interface TelemetryApps {
 }
 
 export interface TelemetrySessions {
+  current: string | null;
   sessions: string[];
 }

--- a/packages/bytebotd/src/telemetry/telemetry.controller.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.ts
@@ -192,8 +192,7 @@ export class TelemetryController {
   }
 
   @Get('sessions')
-  async sessions(): Promise<{ sessions: string[] }> {
-    const sessions = await this.telemetry.listSessions();
-    return { sessions };
+  async sessions(): Promise<{ current: string; sessions: string[] }> {
+    return this.telemetry.listSessions();
   }
 }

--- a/packages/bytebotd/src/telemetry/telemetry.service.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.service.ts
@@ -103,7 +103,7 @@ export class TelemetryService {
     await this.loadDriftForSession(sessionId);
   }
 
-  async listSessions(): Promise<string[]> {
+  async listSessions(): Promise<{ current: string; sessions: string[] }> {
     await this.ready;
     try {
       const entries = await fs.readdir(this.telemetryDir, {
@@ -116,12 +116,13 @@ export class TelemetryService {
       if (!sessions.includes(this.currentSessionId)) {
         sessions.unshift(this.currentSessionId);
       }
-      return Array.from(new Set(sessions));
+      const uniqueSessions = Array.from(new Set(sessions));
+      return { current: this.currentSessionId, sessions: uniqueSessions };
     } catch (error) {
       this.logger.warn(
         `Failed to enumerate telemetry sessions: ${(error as Error).message}`,
       );
-      return [this.currentSessionId];
+      return { current: this.currentSessionId, sessions: [this.currentSessionId] };
     }
   }
 


### PR DESCRIPTION
## Summary
- expose the active telemetry session identifier from the desktop service and include it in the sessions controller response
- proxy the enriched telemetry sessions payload through the agent API with validation to keep the current session visible
- update the UI telemetry status component to track the current session, fall back to the user’s prior choice when the current session disappears, and refresh summaries/reset requests with the active id

## Testing
- npm run lint --prefix packages/bytebot-ui
- npm run lint --prefix packages/bytebot-agent *(fails: existing lint violations throughout the agent package)*

------
https://chatgpt.com/codex/tasks/task_e_68cf50be5b008323bb9a772ccfed3c30