### PR TITLE
Add Radix dialog dependency to UI package

### DIFF
--- a/packages/bytebot-ui/package-lock.json
+++ b/packages/bytebot-ui/package-lock.json
@@ -13,6 +13,7 @@
         "@hugeicons/core-free-icons": "^1.0.14",
         "@hugeicons/react": "^1.0.5",
         "@prisma/client": "^6.5.0",
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.11",

--- a/packages/bytebot-ui/package.json
+++ b/packages/bytebot-ui/package.json
@@ -14,6 +14,7 @@
     "@hugeicons/core-free-icons": "^1.0.14",
     "@hugeicons/react": "^1.0.5",
     "@prisma/client": "^6.5.0",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.11",


### PR DESCRIPTION
## Summary
- add the `@radix-ui/react-dialog` package to the UI workspace so the dialog components have an explicit dependency
- sync the workspace package-lock entry to list the new Radix dependency alongside the existing UI packages

## Testing
- `npm install` *(fails: 403 Forbidden from registry when downloading @radix-ui/react-dialog)*
- `npm run build --prefix packages/bytebot-ui` *(fails: @hugeicons/core-free-icons does not export CloseCircleIcon)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5320e95c8323a55f2f4e1567bd09