### PR TITLE
Fix API key dialog close icon

### DIFF
--- a/packages/bytebot-ui/src/components/settings/ApiKeySettingsDialog.tsx
+++ b/packages/bytebot-ui/src/components/settings/ApiKeySettingsDialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react"
 import * as Dialog from "@radix-ui/react-dialog"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { CloseCircleIcon } from "@hugeicons/core-free-icons"
+import { CancelCircleIcon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -180,7 +180,7 @@ export function ApiKeySettingsDialog({
                 aria-label="Close"
                 className="text-muted-foreground transition hover:text-foreground"
               >
-                <HugeiconsIcon icon={CloseCircleIcon} className="h-6 w-6" />
+                <HugeiconsIcon icon={CancelCircleIcon} className="h-6 w-6" />
               </button>
             </Dialog.Close>
           </div>


### PR DESCRIPTION
## Summary
- replace the unavailable CloseCircle icon import with the CancelCircle icon that exists in @hugeicons/core-free-icons

## Testing
- npm run build --prefix packages/shared
- npm run build (fails: module not found '@radix-ui/react-dialog' because the package cannot be downloaded in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf55a4053c8323966114661da37eb9