### PR TITLE
Surface model metadata in task views

### DIFF
--- a/packages/bytebot-ui/package.json
+++ b/packages/bytebot-ui/package.json
@@ -6,7 +6,8 @@
     "dev": "npm run build --prefix ../shared && tsx server.ts",
     "build": "npm run build --prefix ../shared && next build",
     "start": "npm run build --prefix ../shared && tsx server.ts",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsx --test src/components/tasks/__tests__/TaskItem.test.tsx"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -46,6 +46,7 @@ export default function TaskPage() {
     handleResumeTask,
     handleCancelTask,
     currentTaskId,
+    taskModel,
   } = useChatSession({ initialTaskId: taskId });
 
   // Determine if task is inactive (show screenshot) or active (show VNC)
@@ -91,6 +92,17 @@ export default function TaskPage() {
 
   const taskInactive = isTaskInactive();
 
+  const modelTitle = taskModel?.title?.trim() || taskModel?.name?.trim();
+  const modelProvider = taskModel?.provider?.trim();
+  const modelIdentifier =
+    modelTitle && modelProvider && modelProvider !== modelTitle
+      ? `${modelTitle} (${modelProvider})`
+      : modelTitle || modelProvider;
+  const modelNameDetails =
+    modelTitle && taskModel?.name && taskModel.name !== modelTitle
+      ? taskModel.name
+      : undefined;
+
   // For inactive tasks, auto-load all messages for proper screenshot navigation
   useEffect(() => {
     if (taskInactive && hasMoreMessages && !isLoadingMoreMessages) {
@@ -124,6 +136,19 @@ export default function TaskPage() {
       <Header />
 
       <main className="m-2 flex-1 overflow-hidden px-2 py-4">
+        <div className="mb-4 flex flex-col gap-1 rounded-lg border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-2 px-4 py-3">
+          <span className="text-xs font-semibold uppercase tracking-wide text-bytebot-bronze-light-11">
+            Active Model
+          </span>
+          <span className="text-sm font-semibold text-bytebot-bronze-dark-7">
+            {modelIdentifier || "Model unavailable"}
+          </span>
+          {modelNameDetails && (
+            <span className="text-xs text-bytebot-bronze-light-10">
+              Identifier: {modelNameDetails}
+            </span>
+          )}
+        </div>
         <div className="grid h-full grid-cols-7 gap-4">
           {/* Main container */}
           <div className="col-span-4 flex flex-col gap-3">

--- a/packages/bytebot-ui/src/components/tasks/TaskItem.tsx
+++ b/packages/bytebot-ui/src/components/tasks/TaskItem.tsx
@@ -51,6 +51,19 @@ const STATUS_CONFIGS: Record<TaskStatus, StatusIconConfig> = {
   },
 };
 
+export const getTaskModelLabel = (task: Task): string | null => {
+  const modelTitle = task.model?.title?.trim() || task.model?.name?.trim();
+  const modelProvider = task.model?.provider?.trim();
+
+  if (modelTitle) {
+    return modelProvider && modelProvider !== modelTitle
+      ? `${modelTitle} (${modelProvider})`
+      : modelTitle;
+  }
+
+  return modelProvider || null;
+};
+
 export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
   // Format date to match the screenshot (e.g., "Today 9:13am" or "April 13, 2025, 12:01pm")
   const formatDate = (dateString: string) => {
@@ -67,6 +80,13 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
     const formatted = format(date, formatString).toLowerCase();
     return capitalizeFirstChar(formatted);
   };
+
+  const metadataSegments = [] as string[];
+  const modelLabel = getTaskModelLabel(task);
+  if (modelLabel) {
+    metadataSegments.push(modelLabel);
+  }
+  metadataSegments.push(formatDate(task.createdAt));
 
   const StatusIcon = ({ status }: { status: TaskStatus }) => {
     const config = STATUS_CONFIGS[status];
@@ -99,10 +119,15 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
               {capitalizeFirstChar(task.description)}
             </div>
           </div>
-          <div className="ml-7 flex items-center justify-start space-x-1.5 text-xs">
-            <span className="text-bytebot-bronze-light-10">
-              {formatDate(task.createdAt)}
-            </span>
+          <div className="ml-7 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs">
+            {metadataSegments.map((segment, index) => (
+              <React.Fragment key={`${segment}-${index}`}>
+                {index > 0 && (
+                  <span className="text-bytebot-bronze-light-9">•</span>
+                )}
+                <span className="text-bytebot-bronze-light-10">{segment}</span>
+              </React.Fragment>
+            ))}
           </div>
         </div>
       </div>

--- a/packages/bytebot-ui/src/components/tasks/__tests__/TaskItem.test.tsx
+++ b/packages/bytebot-ui/src/components/tasks/__tests__/TaskItem.test.tsx
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  Role,
+  TaskPriority,
+  TaskStatus,
+  TaskType,
+  Task,
+} from "@/types";
+import { getTaskModelLabel } from "../TaskItem";
+
+const baseTask: Task = {
+  id: "task-1",
+  description: "review pull request",
+  type: TaskType.IMMEDIATE,
+  status: TaskStatus.COMPLETED,
+  priority: TaskPriority.MEDIUM,
+  control: Role.ASSISTANT,
+  createdBy: Role.USER,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  model: {
+    provider: "OpenAI",
+    name: "o1-mini",
+    title: "OpenAI o1-mini",
+  },
+  files: [],
+};
+
+test("includes the provider when present", () => {
+  assert.equal(getTaskModelLabel(baseTask), "OpenAI o1-mini (OpenAI)");
+});
+
+test("falls back to the model name when title is missing", () => {
+  const taskWithoutTitle: Task = {
+    ...baseTask,
+    id: "task-2",
+    model: {
+      provider: "Anthropic",
+      name: "claude-3.7-sonnet",
+      title: "",
+    },
+  };
+
+  assert.equal(getTaskModelLabel(taskWithoutTitle), "claude-3.7-sonnet (Anthropic)");
+});
+
+test("returns provider when title and name are unavailable", () => {
+  const taskWithProviderOnly: Task = {
+    ...baseTask,
+    id: "task-3",
+    model: {
+      provider: "Custom",
+      name: "",
+      title: "",
+    },
+  };
+
+  assert.equal(getTaskModelLabel(taskWithProviderOnly), "Custom");
+});

--- a/packages/bytebot-ui/src/hooks/useChatSession.ts
+++ b/packages/bytebot-ui/src/hooks/useChatSession.ts
@@ -1,5 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Message, Role, TaskStatus, Task, GroupedMessages } from "@/types";
+import {
+  Message,
+  Role,
+  TaskStatus,
+  Task,
+  GroupedMessages,
+  Model,
+} from "@/types";
 import {
   addMessage,
   fetchTaskMessages,
@@ -25,6 +32,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
   const [currentTaskId, setCurrentTaskId] = useState<string | null>(
     initialTaskId || null,
   );
+  const [taskModel, setTaskModel] = useState<Model | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingSession, setIsLoadingSession] = useState(true);
   const [isLoadingMoreMessages, setIsLoadingMoreMessages] = useState(false);
@@ -39,6 +47,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
       if (task.id === currentTaskId) {
         setTaskStatus(task.status);
         setControl(task.control);
+        setTaskModel(task.model ?? null);
       }
     },
     [currentTaskId],
@@ -183,6 +192,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
             setCurrentTaskId(task.id);
             setTaskStatus(task.status); // Set the task status when loading
             setControl(task.control);
+            setTaskModel(task.model ?? null);
 
             // Set grouped messages for chat UI
             setGroupedMessages(processedMessages);
@@ -280,6 +290,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
       const updatedTask = await takeOverTask(currentTaskId);
       if (updatedTask) {
         setControl(updatedTask.control);
+        setTaskModel(updatedTask.model ?? null);
       }
     } catch (error) {
       console.error("Error taking over task:", error);
@@ -293,6 +304,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
       const updatedTask = await resumeTask(currentTaskId);
       if (updatedTask) {
         setControl(updatedTask.control);
+        setTaskModel(updatedTask.model ?? null);
       }
     } catch (error) {
       console.error("Error resuming task:", error);
@@ -307,6 +319,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
       if (updatedTask) {
         setTaskStatus(updatedTask.status);
         setControl(updatedTask.control);
+        setTaskModel(updatedTask.model ?? null);
       }
     } catch (error) {
       console.error("Error cancelling task:", error);
@@ -321,6 +334,7 @@ export function useChatSession({ initialTaskId }: UseChatSessionProps = {}) {
     input,
     setInput,
     currentTaskId,
+    taskModel,
     isLoading,
     isLoadingSession,
     isLoadingMoreMessages,


### PR DESCRIPTION
## Summary
- surface the active model metadata in task list rows and the task session header so users can see which model is running
- expose the task model from the chat session hook for reuse and reuse a helper to format model labels
- add a lightweight unit test and npm script that validates model label rendering across multiple model configurations

## Testing
- npm run lint --prefix packages/bytebot-ui
- npm run test --prefix packages/bytebot-ui

------
https://chatgpt.com/codex/tasks/task_e_68cf59861e688323b0f34df95997dd79