### PR TITLE
Refactor task models endpoint to use persisted API keys

### DIFF
--- a/packages/bytebot-agent/prisma/migrations/20250901000000_api_keys/migration.sql
+++ b/packages/bytebot-agent/prisma/migrations/20250901000000_api_keys/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "ApiKeyName" AS ENUM ('ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'OPENROUTER_API_KEY');
+
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "name" "ApiKeyName" NOT NULL,
+    "value" TEXT,
+    "lastFour" TEXT,
+    "length" INTEGER,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("name")
+);

--- a/packages/bytebot-agent/prisma/schema.prisma
+++ b/packages/bytebot-agent/prisma/schema.prisma
@@ -40,6 +40,13 @@ enum TaskType {
   SCHEDULED
 }
 
+enum ApiKeyName {
+  ANTHROPIC_API_KEY
+  OPENAI_API_KEY
+  GEMINI_API_KEY
+  OPENROUTER_API_KEY
+}
+
 model Task {
   id            String        @id @default(uuid())
   description   String
@@ -106,9 +113,19 @@ model File {
   data          String      // Base64 encoded file data
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
-  
+
   // Relations
   task          Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
   taskId        String
+}
+
+model ApiKey {
+  name      ApiKeyName @id
+  value     String?
+  lastFour  String?
+  length    Int?
+  revokedAt DateTime?
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
 }
 

--- a/packages/bytebot-agent/src/settings/api-keys.module.ts
+++ b/packages/bytebot-agent/src/settings/api-keys.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ApiKeysService } from './api-keys.service';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ApiKeysService],
+  exports: [ApiKeysService],
+})
+export class ApiKeysModule {}

--- a/packages/bytebot-agent/src/settings/api-keys.service.ts
+++ b/packages/bytebot-agent/src/settings/api-keys.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { ApiKeyName } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ApiKeysService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getConfiguredKeyNames(): Promise<ApiKeyName[]> {
+    const keys = await this.prisma.apiKey.findMany({
+      where: {
+        revokedAt: null,
+      },
+      select: {
+        name: true,
+        value: true,
+      },
+    });
+
+    return keys
+      .filter((key) => Boolean(key.value))
+      .map((key) => key.name);
+  }
+}

--- a/packages/bytebot-agent/src/tasks/tasks.controller.spec.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+import { MessagesService } from '../messages/messages.service';
+import { ApiKeysService } from '../settings/api-keys.service';
+import { ApiKeyName } from '@prisma/client';
+import { ConfigService } from '@nestjs/config';
+import { ANTHROPIC_MODELS } from '../anthropic/anthropic.constants';
+import { OPENAI_MODELS } from '../openai/openai.constants';
+import { GOOGLE_MODELS } from '../google/google.constants';
+
+class InMemoryApiKeysService {
+  private configured = new Set<ApiKeyName>();
+
+  async getConfiguredKeyNames(): Promise<ApiKeyName[]> {
+    return Array.from(this.configured);
+  }
+
+  setConfigured(names: ApiKeyName[] = []) {
+    this.configured = new Set(names);
+  }
+}
+
+class MutableConfigService {
+  private values = new Map<string, string>();
+
+  get<T = any>(key: string): T | undefined {
+    return this.values.get(key) as T | undefined;
+  }
+
+  set(key: string, value?: string) {
+    if (typeof value === 'undefined') {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
+
+describe('TasksController - getModels', () => {
+  let controller: TasksController;
+  let apiKeysService: InMemoryApiKeysService;
+  let configService: MutableConfigService;
+
+  beforeEach(async () => {
+    apiKeysService = new InMemoryApiKeysService();
+    configService = new MutableConfigService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TasksController],
+      providers: [
+        { provide: TasksService, useValue: { create: jest.fn(), findAll: jest.fn() } },
+        { provide: MessagesService, useValue: {} },
+        { provide: ApiKeysService, useValue: apiKeysService },
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    controller = module.get<TasksController>(TasksController);
+  });
+
+  it('reflects persisted API key changes without restart', async () => {
+    await expect(controller.getModels()).resolves.toEqual([]);
+
+    apiKeysService.setConfigured([ApiKeyName.ANTHROPIC_API_KEY]);
+    await expect(controller.getModels()).resolves.toEqual(ANTHROPIC_MODELS);
+
+    apiKeysService.setConfigured([ApiKeyName.OPENAI_API_KEY]);
+    await expect(controller.getModels()).resolves.toEqual(OPENAI_MODELS);
+
+    apiKeysService.setConfigured([
+      ApiKeyName.ANTHROPIC_API_KEY,
+      ApiKeyName.GEMINI_API_KEY,
+    ]);
+    await expect(controller.getModels()).resolves.toEqual([
+      ...ANTHROPIC_MODELS,
+      ...GOOGLE_MODELS,
+    ]);
+
+    apiKeysService.setConfigured([]);
+    configService.set('OPENAI_API_KEY', 'from-env');
+    await expect(controller.getModels()).resolves.toEqual(OPENAI_MODELS);
+
+    configService.set('OPENAI_API_KEY');
+  });
+});

--- a/packages/bytebot-agent/src/tasks/tasks.module.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.module.ts
@@ -4,9 +4,10 @@ import { TasksService } from './tasks.service';
 import { TasksGateway } from './tasks.gateway';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MessagesModule } from '../messages/messages.module';
+import { ApiKeysModule } from '../settings/api-keys.module';
 
 @Module({
-  imports: [PrismaModule, MessagesModule],
+  imports: [PrismaModule, MessagesModule, ApiKeysModule],
   controllers: [TasksController],
   providers: [TasksService, TasksGateway],
   exports: [TasksService, TasksGateway],


### PR DESCRIPTION
## Summary
- add a persisted ApiKey enum/table in Prisma to support provider key metadata
- expose a new ApiKeysService/module and refactor the tasks model endpoint to query persisted key state on every request with env fallbacks
- add unit coverage confirming `/tasks/models` reacts to API key toggles without restarting the service

## Testing
- npm run build --prefix packages/shared
- npm test --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68cf598cda8c8323a73b3d54ad9d8388