### PR TITLE
Fix unresolved tool call sanitization

### DIFF
--- a/packages/bytebot-agent/src/proxy/proxy.service.spec.ts
+++ b/packages/bytebot-agent/src/proxy/proxy.service.spec.ts
@@ -69,4 +69,67 @@ describe('ProxyService sanitizeChatMessages', () => {
 
     expect(serializedContent).toContain('[tool-call:doSomething] unresolved');
   });
+
+  it('retains resolved tool calls while flagging unresolved ones after screenshot message', () => {
+    const service = createService();
+
+    const messages: ChatCompletionMessageParam[] = [
+      {
+        role: 'assistant',
+        content: 'Initiating tools...',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'takeScreenshot',
+              arguments: '{}',
+            },
+          },
+          {
+            id: 'call_2',
+            type: 'function',
+            function: {
+              name: 'fetchData',
+              arguments: '{"query":"status"}',
+            },
+          },
+        ],
+      } as any,
+      {
+        role: 'tool',
+        tool_call_id: 'call_1',
+        content: 'screenshot',
+      } as any,
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Screenshot' },
+          {
+            type: 'image_url',
+            image_url: {
+              url: 'data:image/png;base64,AAA',
+              detail: 'high',
+            },
+          },
+        ],
+      } as any,
+    ];
+
+    const sanitized = (service as any).sanitizeChatMessages(messages);
+
+    expect(sanitized).toHaveLength(3);
+    const assistant = sanitized[0] as any;
+
+    expect(Array.isArray(assistant.tool_calls)).toBe(true);
+    expect(assistant.tool_calls).toHaveLength(1);
+    expect(assistant.tool_calls[0].id).toBe('call_1');
+
+    const assistantContent =
+      typeof assistant.content === 'string'
+        ? assistant.content
+        : JSON.stringify(assistant.content);
+
+    expect(assistantContent).toContain('[tool-call:fetchData] unresolved');
+  });
 });


### PR DESCRIPTION
## Summary
- filter out only unresolved tool call IDs when sanitizing assistant messages so resolved entries remain intact
- ensure unresolved tool calls continue to be flagged via fallback content
- add regression coverage for screenshot tool results that arrive before another tool reply

## Testing
- npm run build --prefix ../shared
- npm test -- proxy/proxy.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf6544e7d88323ac74c167bdfad945