### PR TITLE
Add write file tool to agent toolsets

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.tools.ts
@@ -456,6 +456,26 @@ export const _readFileTool = {
   },
 };
 
+export const _writeFileTool = {
+  name: 'computer_write_file',
+  description:
+    'Writes base64 encoded data to the specified file path, creating or overwriting the file as needed',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      path: {
+        type: 'string' as const,
+        description: 'The file path to write to',
+      },
+      data: {
+        type: 'string' as const,
+        description: 'Base64 encoded file contents to write',
+      },
+    },
+    required: ['path', 'data'],
+  },
+};
+
 /**
  * Export all tools as an array
  */
@@ -479,4 +499,5 @@ export const agentTools = [
   _setTaskStatusTool,
   _createTaskTool,
   _readFileTool,
+  _writeFileTool,
 ];

--- a/packages/bytebot-agent/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent/src/agent/agent.tools.ts
@@ -507,6 +507,26 @@ export const _readFileTool = {
   },
 };
 
+export const _writeFileTool = {
+  name: 'computer_write_file',
+  description:
+    'Writes base64 encoded data to the specified file path, creating or overwriting the file as needed',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      path: {
+        type: 'string' as const,
+        description: 'The file path to write to',
+      },
+      data: {
+        type: 'string' as const,
+        description: 'Base64 encoded file contents to write',
+      },
+    },
+    required: ['path', 'data'],
+  },
+};
+
 /**
  * Export all tools as an array
  */
@@ -531,4 +551,5 @@ export const agentTools = [
   _setTaskStatusTool,
   _createTaskTool,
   _readFileTool,
+  _writeFileTool,
 ];


### PR DESCRIPTION
## Summary
- add a computer_write_file tool definition with path and base64 data schemas
- expose the new write file tool in both agent tool arrays so provider adapters inherit it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf697a811883239c2ec2f26d7621eb