### PR TITLE
Document computer trace mouse usage

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.constants.ts
@@ -94,12 +94,13 @@ QUICK PATTERNS for common elements:
 
 2. **Navigate applications**  = *Always* invoke \`computer_application\` to switch between the default applications.
 3. **Tool Discipline & Efficient Mapping**
-   • Map any plain-language request to the most direct tool sequence; prefer tools over speculation.  
-   • Text entry: \`computer_type_text\` for ≤ 25 chars; \`computer_paste_text\` for longer or complex text.  
-   • Files: use \`computer_write_file\` / \`computer_read_file\` to create and verify artifacts.  
+   • Map any plain-language request to the most direct tool sequence; prefer tools over speculation.
+   • Text entry: \`computer_type_text\` for ≤ 25 chars; \`computer_paste_text\` for longer or complex text.
+   • Files: use \`computer_write_file\` / \`computer_read_file\` to create and verify artifacts.
    • Apps: \`computer_application\` to open/focus; avoid unreliable shortcuts.
+   • Pointer paths: use \`computer_trace_mouse\` for smooth multi-point motion or constrained drags. Supply the full path, include \`holdKeys\` when a modifier (e.g., Shift to lock direction) must stay pressed, and remember it only moves the pointer—use \`computer_drag_mouse\` when the button must stay held the entire time.
 4. **Human-Like Interaction**
-   • Move in smooth, purposeful paths; click near the visual centre of targets.  
+   • Move in smooth, purposeful paths; click near the visual centre of targets.
    • Double-click desktop icons to open them.  
    • Type realistic, context-appropriate text with \`computer_type_text\` (for short strings) or \`computer_paste_text\` (for long strings), or shortcuts with \`computer_type_keys\`.
 4. **Valid Keys Only** - 

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -79,6 +79,7 @@ PRIMARY TOOLS
 • computer_screenshot_region – Capture named 3×3 regions; supports gridSize, enhance, includeOffset, addHighlight, and progress metadata.
 • computer_screenshot_custom_region – Capture arbitrary rectangles (x, y, width, height) with optional gridSize/zoomLevel for progressive zoom.
 • computer_click_mouse – Fallback when no reliable keyboard path exists. Supply precise coordinates and (when possible) a description; include region/zoom/source context when you already know it.
+• computer_trace_mouse – For smooth multi-point motion or constrained drags. Provide the full path, add holdKeys when a modifier (e.g., Shift for straight lines) must stay engaged, and remember it only moves—use computer_drag_mouse when the pointer should keep the button held down the entire way.
 • computer_move_mouse, computer_press_mouse, computer_drag_mouse, computer_scroll, computer_type_text, computer_paste_text, computer_type_keys, computer_press_keys, computer_wait, computer_cursor_position.
 • computer_application – Focus one of: firefox, thunderbird, 1password, vscode, terminal, directory, desktop.
 • computer_read_file – Retrieve file contents for inspection.


### PR DESCRIPTION
## Summary
- add guidance in the primary tools list about when to use `computer_trace_mouse` and how it differs from drags
- mirror the new pointer path guidance in the cc agent constants so both prompts stay aligned

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf69e1eccc8323b5c88b63cf972737