### PR TITLE
Document pointer tool modifiers in agent prompts

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.constants.ts
@@ -94,9 +94,10 @@ QUICK PATTERNS for common elements:
 
 2. **Navigate applications**  = *Always* invoke \`computer_application\` to switch between the default applications.
 3. **Tool Discipline & Efficient Mapping**
-   • Map any plain-language request to the most direct tool sequence; prefer tools over speculation.  
-   • Text entry: \`computer_type_text\` for ≤ 25 chars; \`computer_paste_text\` for longer or complex text.  
-   • Files: use \`computer_write_file\` / \`computer_read_file\` to create and verify artifacts.  
+   • Map any plain-language request to the most direct tool sequence; prefer tools over speculation.
+   • Text entry: \`computer_type_text\` for ≤ 25 chars; \`computer_paste_text\` for longer or complex text.
+   • Pointer tools (\`computer_click_mouse\`, \`computer_trace_mouse\`, \`computer_drag_mouse\`, \`computer_scroll\`) accept an optional \`holdKeys\` array for modifier-assisted gestures such as Shift-click ranges or Ctrl/Alt drags.
+   • Files: use \`computer_write_file\` / \`computer_read_file\` to create and verify artifacts.
    • Apps: \`computer_application\` to open/focus; avoid unreliable shortcuts.
 4. **Human-Like Interaction**
    • Move in smooth, purposeful paths; click near the visual centre of targets.  

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -61,6 +61,7 @@ OPERATING PRINCIPLES
    - Prefer computer_click_mouse with explicit coordinates derived from grids, Smart Focus outputs, or binary search.
    - When computing coordinates manually, explain the math ("one grid square right of the 500 line" etc.).
    - If you do NOT supply coordinates, you MUST include a short target description (3–6 words, e.g., "OK button", "Search field"). The tool will be rejected without it and Smart Focus will not run.
+   - Pointer tools (computer_click_mouse, computer_trace_mouse, computer_drag_mouse, computer_scroll) accept an optional holdKeys array—use it for modifier-assisted gestures such as Shift-click ranges or Ctrl/Alt drags.
    - When possible, include a coarse grid hint (e.g., "~X=600,Y=420" or "near Y=400 one square right of X=500").
    - After clicking, glance at the pointer location or UI feedback to confirm success.
 8. Human-Like Interaction


### PR DESCRIPTION
## Summary
- note that pointer interaction tools accept a `holdKeys` array for modifier-assisted gestures in the primary agent prompt
- mirror the pointer tool modifier guidance in the cc agent prompt for consistency

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf6a1f6ec8832383da168929a67629