### PR TITLE
Show active model on desktop page

### DIFF
--- a/packages/bytebot-ui/src/app/desktop/page.tsx
+++ b/packages/bytebot-ui/src/app/desktop/page.tsx
@@ -3,8 +3,64 @@
 import React from "react";
 import { Header } from "@/components/layout/Header";
 import { DesktopContainer } from "@/components/ui/desktop-container";
+import { fetchTasks } from "@/utils/taskUtils";
+import { Task, TaskStatus } from "@/types";
+import { getTaskModelLabel } from "@/components/tasks/TaskItem";
+
+const ACTIVE_TASK_STATUSES: TaskStatus[] = [
+  TaskStatus.PENDING,
+  TaskStatus.RUNNING,
+  TaskStatus.NEEDS_HELP,
+  TaskStatus.NEEDS_REVIEW,
+];
 
 export default function DesktopPage() {
+  const [activeTask, setActiveTask] = React.useState<Task | null>(null);
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    const loadActiveTask = async () => {
+      try {
+        const result = await fetchTasks({
+          statuses: ACTIVE_TASK_STATUSES,
+          limit: 1,
+        });
+
+        if (!isMounted) return;
+        setActiveTask(result.tasks[0] ?? null);
+      } catch (error) {
+        console.error("Failed to fetch active task:", error);
+        if (!isMounted) return;
+        setActiveTask(null);
+      }
+    };
+
+    void loadActiveTask();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const modelLabel = React.useMemo(
+    () => (activeTask ? getTaskModelLabel(activeTask) : null),
+    [activeTask]
+  );
+
+  const modelNameDetails = React.useMemo(() => {
+    if (!activeTask?.model) return undefined;
+
+    const title = activeTask.model.title?.trim();
+    const name = activeTask.model.name?.trim();
+
+    if (title && name && title !== name) {
+      return name;
+    }
+
+    return undefined;
+  }, [activeTask]);
+
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <Header />
@@ -12,7 +68,20 @@ export default function DesktopPage() {
       <main className="m-2 flex-1 overflow-hidden px-2 py-4">
         <div className="flex h-full items-center justify-center">
           {/* Main container */}
-          <div className="w-[60%]">
+          <div className="w-[60%] space-y-4">
+            <div className="mb-4 flex flex-col gap-1 rounded-lg border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-2 px-4 py-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-bytebot-bronze-light-11">
+                Active Model
+              </span>
+              <span className="text-sm font-semibold text-bytebot-bronze-dark-7">
+                {modelLabel || "Model unavailable"}
+              </span>
+              {modelNameDetails && (
+                <span className="text-xs text-bytebot-bronze-light-10">
+                  Identifier: {modelNameDetails}
+                </span>
+              )}
+            </div>
             <DesktopContainer viewOnly={false} status="live_view">
               {/* No action buttons for desktop page */}
             </DesktopContainer>


### PR DESCRIPTION
## Summary
- load the most recent active task on the desktop page to inspect its model
- reuse the task item helper to format the model name and display it in a banner before the desktop container
- include additional identifier details when available to match the task detail view styling

## Testing
- `npm run lint --prefix packages/bytebot-ui` *(fails: `next` binary unavailable prior to installing dependencies)*
- `npm install --prefix packages/bytebot-ui` *(fails: npm registry returned 403 for @radix-ui/react-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68cf77d624b88323860cccec8543b00a