### PR TITLE
Document task management tool usage

### DIFF
--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -89,7 +89,11 @@ PRIMARY TOOLS
 • computer_application – Focus one of: firefox, thunderbird, 1password, vscode, terminal, directory, desktop.
 • computer_write_file – Save base64-encoded data to create or modify files; prefer this for file edits.
 • computer_read_file – Retrieve file contents for inspection.
-• Task management: create_task, set_task_status (completed, needs_help).
+• Task management:
+  - create_task – Use for follow-up work or to schedule future actions; include priority and/or scheduledFor when relevant.
+    Example: create_task({ title: 'Review deployment metrics', priority: 'high', scheduledFor: '2024-05-01T15:00:00Z' }).
+  - set_task_status – Use to close the loop with a completion summary or to flag blockers with status: 'needs_help'.
+    Examples: set_task_status({ status: 'completed', summary: 'UI regression reproduced and logs saved.' }); set_task_status({ status: 'needs_help', summary: 'Blocked on VPN access; cannot reach staging.' }).
 
 ════════════════════════════════
 STANDARD LOOP


### PR DESCRIPTION
## Summary
- expand the task management guidance in the agent system prompt with clearer usage scenarios
- add inline examples for create_task and set_task_status payloads

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68cf92d7308c83239fe0800aab346967