### PR TITLE
Fix typo in task title text color class

### DIFF
--- a/packages/bytebot-ui/src/components/tasks/TaskItem.tsx
+++ b/packages/bytebot-ui/src/components/tasks/TaskItem.tsx
@@ -115,7 +115,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
         <div className="mb-0.5 flex-1 space-y-2">
           <div className="flex items-center justify-start space-x-2">
             <StatusIcon status={task.status} />
-            <div className="text-byhtebot-bronze-dark-7 text-sm font-medium">
+            <div className="text-bytebot-bronze-dark-7 text-sm font-medium">
               {capitalizeFirstChar(task.description)}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- correct the TaskItem title text color class name to use the bytebot prefix
- confirm no other instances of the misspelled prefix remain in the UI package

## Testing
- Not run (relied on existing UI snapshots)

------
https://chatgpt.com/codex/tasks/task_e_68cf9bfc88488323bcb8c97d895a58bb