### PR TITLE
Add theme provider wrapper around app layout

### DIFF
--- a/packages/bytebot-ui/src/app/layout.tsx
+++ b/packages/bytebot-ui/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import type { Metadata } from "next";
+import { ThemeProvider } from "@/components/theme/ThemeProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -14,7 +15,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="font-sans antialiased">{children}</body>
+      <body className="font-sans antialiased">
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/packages/bytebot-ui/src/components/theme/ThemeProvider.tsx
+++ b/packages/bytebot-ui/src/components/theme/ThemeProvider.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import type { ThemeProviderProps } from 'next-themes';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client ThemeProvider wrapper that configures next-themes defaults
- wrap the app layout body with ThemeProvider to expose theme context to children

## Testing
- `npm run lint` *(fails: `next` binary missing because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9d7f996083239d504e20eeac99a9