### PR TITLE
Add header theme toggle control

### DIFF
--- a/packages/bytebot-ui/src/components/layout/Header.tsx
+++ b/packages/bytebot-ui/src/components/layout/Header.tsx
@@ -15,6 +15,7 @@ import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { ApiKeySettingsDialog } from "@/components/settings/ApiKeySettingsDialog";
+import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
   const { resolvedTheme } = useTheme();
@@ -94,6 +95,7 @@ export function Header() {
         </div>
       </div>
       <div className="flex items-center gap-3">
+        <ThemeToggle />
         <Button
           type="button"
           variant="ghost"

--- a/packages/bytebot-ui/src/components/layout/ThemeToggle.tsx
+++ b/packages/bytebot-ui/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleToggle = () => {
+    if (!mounted) {
+      return;
+    }
+
+    const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+  };
+
+  const isDark = resolvedTheme === "dark";
+  const ariaLabel = isDark ? "Switch to light theme" : "Switch to dark theme";
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={handleToggle}
+      aria-label={ariaLabel}
+      aria-pressed={isDark}
+      className="relative"
+    >
+      {mounted ? (
+        <>
+          <Sun
+            aria-hidden="true"
+            className={cn(
+              "h-5 w-5 transition-transform duration-200",
+              isDark ? "scale-0" : "scale-100"
+            )}
+          />
+          <Moon
+            aria-hidden="true"
+            className={cn(
+              "absolute h-5 w-5 transition-transform duration-200",
+              isDark ? "scale-100" : "scale-0"
+            )}
+          />
+        </>
+      ) : (
+        <span className="h-5 w-5" />
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable ThemeToggle client component that switches between light and dark themes via next-themes
- include the new toggle alongside the header settings button while preserving existing layout spacing

## Testing
- npm run lint *(fails: next not found because dependencies are not installed in the environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cf9e6d57c08323acda792027d63ff2