### PR TITLE
Improve theme-aware styling for header and hero

### DIFF
--- a/packages/bytebot-ui/src/app/page.tsx
+++ b/packages/bytebot-ui/src/app/page.tsx
@@ -20,7 +20,7 @@ const StockPhoto: React.FC<StockPhotoProps> = ({
   alt = "Decorative image",
 }) => {
   return (
-    <div className="h-full w-full overflow-hidden rounded-lg bg-white">
+    <div className="h-full w-full overflow-hidden rounded-lg bg-card shadow-sm dark:bg-muted">
       <div className="relative h-full w-full">
         <Image src={src} alt={alt} fill className="object-cover" priority />
       </div>
@@ -141,12 +141,12 @@ export default function Home() {
           <div className="flex flex-col items-center overflow-y-auto">
             <div className="flex w-full max-w-xl flex-col items-center">
               <div className="mb-6 flex w-full flex-col items-start justify-start">
-                <h1 className="text-bytebot-bronze-light-12 mb-1 text-2xl">
+                <h1 className="mb-1 text-2xl text-foreground">
                   What can I help you get done?
                 </h1>
               </div>
 
-              <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-7 mb-10 w-full rounded-2xl border p-2">
+              <div className="mb-10 w-full rounded-2xl border border-border bg-card p-2 shadow-sm dark:bg-muted">
                 <ChatInput
                   input={input}
                   isLoading={isLoading}
@@ -199,12 +199,12 @@ export default function Home() {
           <div className="flex flex-1 flex-col items-center overflow-y-auto px-4 pt-10">
             <div className="flex w-full max-w-xl flex-col items-center pb-10">
               <div className="mb-6 flex w-full flex-col items-start justify-start">
-                <h1 className="text-bytebot-bronze-light-12 mb-1 text-2xl">
+                <h1 className="mb-1 text-2xl text-foreground">
                   What can I help you get done?
                 </h1>
               </div>
 
-              <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-5 borderw-full mb-10 rounded-2xl p-2">
+              <div className="mb-10 w-full rounded-2xl border border-border bg-card p-2 shadow-sm dark:bg-muted">
                 <ChatInput
                   input={input}
                   isLoading={isLoading}

--- a/packages/bytebot-ui/src/components/layout/Header.tsx
+++ b/packages/bytebot-ui/src/components/layout/Header.tsx
@@ -39,13 +39,15 @@ export function Header() {
   // Get classes for navigation links based on active state
   const getLinkClasses = (path: string) => {
     const baseClasses =
-      "flex items-center gap-1.5 transition-colors px-3 py-1.5 rounded-lg";
+      "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
     const activeClasses =
-      "bg-bytebot-bronze-light-a3 text-bytebot-bronze-light-12";
+      "bg-muted text-foreground shadow-sm dark:bg-muted dark:text-foreground";
     const inactiveClasses =
-      "text-bytebot-bronze-dark-9 hover:bg-bytebot-bronze-light-a1 hover:text-bytebot-bronze-light-12";
+      "text-muted-foreground hover:bg-muted/80 hover:text-foreground dark:text-muted-foreground dark:hover:bg-muted/60";
 
-    return `${baseClasses} ${isActive(path) ? activeClasses : inactiveClasses}`;
+    return `${baseClasses} ${
+      isActive(path) ? activeClasses : inactiveClasses
+    }`;
   };
 
   return (
@@ -69,7 +71,7 @@ export function Header() {
             <div className="h-8 w-[110px]" />
           )}
         </div>
-        <div className="border-bytebot-bronze-dark-11 h-5 border border-l-[0.5px]"></div>
+        <div className="h-5 border border-l-[0.5px] border-border/60 dark:border-border"></div>
         <div className="flex items-center gap-2">
           <Link href="/" className={getLinkClasses("/")}>
             <HugeiconsIcon icon={Home01Icon} className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- update the header navigation link styling to use theme tokens and add dark mode variants for better contrast
- align the desktop and mobile hero call-to-action blocks with theme-aware text, border, and background tokens so they stay legible in both themes
- ensure supporting hero media tiles inherit the same theme-aware surfaces for consistent contrast

## Testing
- `npm run lint --prefix packages/bytebot-ui` *(fails: `next` command missing because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d00f4d6e9083239beb9a9785bd9c8a