### PR TITLE
Prioritize user-selected telemetry session

### DIFF
--- a/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
+++ b/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
@@ -17,14 +17,14 @@ export function TelemetryStatus({ className = "" }: Props) {
   const [selectedSession, setSelectedSession] = useState<string>("");
 
   const effectiveSession = useMemo(() => {
-    if (currentSession && sessions.includes(currentSession)) {
-      return currentSession;
-    }
     if (preferredSession && sessions.includes(preferredSession)) {
       return preferredSession;
     }
     if (selectedSession && sessions.includes(selectedSession)) {
       return selectedSession;
+    }
+    if (currentSession && sessions.includes(currentSession)) {
+      return currentSession;
     }
     return sessions[0] ?? "";
   }, [currentSession, preferredSession, selectedSession, sessions]);


### PR DESCRIPTION
## Summary
- prefer the user-selected telemetry session when deriving the effective session
- keep the existing selection unless the computed effective session actually changes

## Testing
- npm run lint --prefix packages/bytebot-ui *(fails: next command not available in container)*
- npm install --prefix packages/bytebot-ui *(fails: registry access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68d0128c04288323873b806a1a7e2fc3