### PR TITLE
Use semantic tokens for select component styling

### DIFF
--- a/packages/bytebot-ui/src/components/ui/select.tsx
+++ b/packages/bytebot-ui/src/components/ui/select.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-6 w-full items-center justify-between rounded-md border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-1 pr-1 pl-2 py-[0.5px] text-[12px] text-bytebot-bronze-dark-9 ring-offset-bytebot-bronze-light-7 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-6 w-full items-center justify-between rounded-md border border-border bg-card pr-1 pl-2 py-[0.5px] text-[12px] text-foreground ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-muted/80",
       className
     )}
     {...props}
@@ -41,7 +41,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-1 text-bytebot-bronze-dark-9 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-card text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:bg-muted/80",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -69,7 +69,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-[12px] font-semibold text-bytebot-bronze-dark-9", className)}
+    className={cn("py-1.5 pl-8 pr-2 text-[12px] font-semibold text-muted-foreground dark:text-muted-foreground", className)}
     {...props}
   />
 ))
@@ -82,7 +82,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full justify-between cursor-default select-none items-center rounded-sm py-[0.5px] px-1 text-[12px] text-bytebot-bronze-dark-9 outline-none focus:bg-bytebot-bronze-light-5 focus:text-bytebot-bronze-dark-9 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full justify-between cursor-default select-none items-center rounded-sm py-[0.5px] px-1 text-[12px] text-foreground outline-none focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-muted/80",
       className
     )}
     {...props}
@@ -103,7 +103,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-bytebot-bronze-light-7", className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- update select trigger, content, label, item, and separator to use semantic Tailwind tokens
- add dark theme overrides so the trigger and menu match surrounding surfaces

## Testing
- npm install *(fails: registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d0149e79d4832385eafc613b3d699e