### PR TITLE
Refine task UI theming

### DIFF
--- a/packages/bytebot-ui/src/app/tasks/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/page.tsx
@@ -129,22 +129,20 @@ function TasksPageContent() {
 
           {isLoading ? (
             <div className="p-8 text-center">
-              <div className="border-bytebot-bronze-light-5 border-t-bytebot-bronze mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4"></div>
-              <p className="text-gray-500">Loading tasks...</p>
+              <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary"></div>
+              <p className="text-sm text-muted-foreground">Loading tasks...</p>
             </div>
           ) : tasks.length === 0 ? (
-            <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-7 rounded-xl border p-8 text-center">
+            <div className="rounded-xl border border-border bg-card p-8 text-center">
               <div className="flex flex-col items-center justify-center">
-                <h3 className="text-bytebot-bronze-light-12 mb-1 text-lg font-medium">
+                <h3 className="mb-1 text-lg font-medium text-foreground">
                   No tasks yet
                 </h3>
-                <p className="text-bytebot-bronze-light-11 mb-6 text-sm">
+                <p className="mb-6 text-sm text-muted-foreground">
                   Get started by creating a first task
                 </p>
                 <Link href="/">
-                  <Button className="bg-bytebot-bronze-dark-7 hover:bg-bytebot-bronze-dark-6 text-white">
-                    + New Task
-                  </Button>
+                  <Button>+ New Task</Button>
                 </Link>
               </div>
             </div>
@@ -176,8 +174,8 @@ function TasksPageContent() {
 function TasksPageFallback() {
   return (
     <div className="p-8 text-center">
-      <div className="border-bytebot-bronze-light-5 border-t-bytebot-bronze mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4"></div>
-      <p className="text-gray-500">Loading tasks...</p>
+      <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary"></div>
+      <p className="text-sm text-muted-foreground">Loading tasks...</p>
     </div>
   );
 }

--- a/packages/bytebot-ui/src/components/tasks/TaskItem.tsx
+++ b/packages/bytebot-ui/src/components/tasks/TaskItem.tsx
@@ -25,29 +25,29 @@ interface StatusIconConfig {
 const STATUS_CONFIGS: Record<TaskStatus, StatusIconConfig> = {
   [TaskStatus.COMPLETED]: {
     icon: Tick02Icon,
-    color: "text-bytebot-green-8",
+    color: "text-emerald-500 dark:text-emerald-400",
   },
   [TaskStatus.RUNNING]: {
     useLoader: true,
   },
   [TaskStatus.NEEDS_HELP]: {
     icon: AlertCircleIcon,
-    color: "text-[#FF9D00]",
+    color: "text-amber-500 dark:text-amber-400",
   },
   [TaskStatus.PENDING]: {
     useLoader: true,
   },
   [TaskStatus.FAILED]: {
     icon: AlertCircleIcon,
-    color: "text-bytebot-red-light-9",
+    color: "text-destructive",
   },
   [TaskStatus.NEEDS_REVIEW]: {
     icon: AlertCircleIcon,
-    color: "text-[#FF9D00]",
+    color: "text-amber-500 dark:text-amber-400",
   },
   [TaskStatus.CANCELLED]: {
     icon: CancelCircleIcon,
-    color: "text-bytebot-bronze-light-10",
+    color: "text-muted-foreground",
   },
 };
 
@@ -111,11 +111,11 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
 
   return (
     <Link href={`/tasks/${task.id}`} className="block">
-      <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-7 hover:bg-bytebot-bronze-light-3 flex min-h-24 items-start rounded-lg border p-5 transition-colors">
+      <div className="flex min-h-24 items-start rounded-lg border border-border bg-card p-5 transition-colors hover:bg-muted/70">
         <div className="mb-0.5 flex-1 space-y-2">
           <div className="flex items-center justify-start space-x-2">
             <StatusIcon status={task.status} />
-            <div className="text-bytebot-bronze-dark-7 text-sm font-medium">
+            <div className="text-sm font-medium text-foreground">
               {capitalizeFirstChar(task.description)}
             </div>
           </div>
@@ -123,9 +123,9 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
             {metadataSegments.map((segment, index) => (
               <React.Fragment key={`${segment}-${index}`}>
                 {index > 0 && (
-                  <span className="text-bytebot-bronze-light-9">•</span>
+                  <span className="text-muted-foreground">•</span>
                 )}
-                <span className="text-bytebot-bronze-light-10">{segment}</span>
+                <span className="text-muted-foreground">{segment}</span>
               </React.Fragment>
             ))}
           </div>

--- a/packages/bytebot-ui/src/components/tasks/TaskTabs.tsx
+++ b/packages/bytebot-ui/src/components/tasks/TaskTabs.tsx
@@ -7,6 +7,7 @@ import {
   MultiplicationSignIcon,
   ListViewIcon,
 } from "@hugeicons/core-free-icons";
+import { cn } from "@/lib/utils";
 
 type TabKey = "ALL" | "ACTIVE" | "COMPLETED" | "CANCELLED_FAILED";
 
@@ -23,7 +24,6 @@ interface TabConfig {
     | typeof CursorProgress04Icon
     | typeof MultiplicationSignIcon
     | typeof ListViewIcon;
-  color: string;
   statuses: TaskStatus[];
 }
 
@@ -31,13 +31,11 @@ const TAB_CONFIGS: Record<TabKey, TabConfig> = {
   ALL: {
     label: "All",
     icon: ListViewIcon,
-    color: "text-bytebot-bronze-light-10",
     statuses: Object.values(TaskStatus),
   },
   ACTIVE: {
     label: "Active",
     icon: CursorProgress04Icon,
-    color: "text-bytebot-bronze-light-10",
     statuses: [
       TaskStatus.PENDING,
       TaskStatus.RUNNING,
@@ -48,13 +46,11 @@ const TAB_CONFIGS: Record<TabKey, TabConfig> = {
   COMPLETED: {
     label: "Completed",
     icon: Tick02Icon,
-    color: "text-bytebot-bronze-light-10",
     statuses: [TaskStatus.COMPLETED],
   },
   CANCELLED_FAILED: {
     label: "Cancelled/Failed",
     icon: MultiplicationSignIcon,
-    color: "text-bytebot-bronze-light-10",
     statuses: [TaskStatus.CANCELLED, TaskStatus.FAILED],
   },
 };
@@ -67,7 +63,7 @@ export const TaskTabs: React.FC<TaskTabsProps> = ({
   const tabs = Object.entries(TAB_CONFIGS) as [TabKey, TabConfig][];
 
   return (
-    <div className="border-bytebot-bronze-light-7 mb-6 border-b">
+    <div className="mb-6 border-b border-border">
       <div className="flex overflow-x-auto">
         {tabs.map(([tabKey, config]) => {
           const isActive = activeTab === tabKey;
@@ -77,24 +73,28 @@ export const TaskTabs: React.FC<TaskTabsProps> = ({
             <button
               key={tabKey}
               onClick={() => onTabChange(tabKey)}
-              className={`flex cursor-pointer items-center space-x-2 border-b-2 px-4 py-3 whitespace-nowrap transition-colors ${
-                isActive
-                  ? "border-bytebot-bronze-dark-7 text-bytebot-bronze-dark-7"
-                  : "text-bytebot-bronze-light-10 hover:text-bytebot-bronze-dark-7 border-transparent"
-              }`}
+              className={cn(
+                "flex cursor-pointer items-center space-x-2 whitespace-nowrap border-b-2 border-transparent px-4 py-3 text-sm font-medium text-muted-foreground transition-colors",
+                isActive && "border-primary text-foreground",
+                !isActive && "hover:text-foreground"
+              )}
             >
               <HugeiconsIcon
                 icon={config.icon}
-                className={`h-4 w-4 ${isActive ? "text-bytebot-bronze-dark-7" : config.color}`}
+                className={cn(
+                  "h-4 w-4",
+                  isActive ? "text-foreground" : "text-muted-foreground"
+                )}
               />
-              <span className="text-sm font-medium">{config.label}</span>
+              <span>{config.label}</span>
               {count > 0 && (
                 <span
-                  className={`rounded-full px-2 py-0.5 text-xs ${
+                  className={cn(
+                    "rounded-full px-2 py-0.5 text-xs font-medium",
                     isActive
-                      ? "bg-bytebot-bronze-dark-7 text-white"
-                      : "bg-bytebot-bronze-light-7 text-bytebot-bronze-light-11"
-                  }`}
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-accent text-muted-foreground dark:bg-accent/40"
+                  )}
                 >
                   {count}
                 </span>

--- a/packages/bytebot-ui/src/components/ui/pagination.tsx
+++ b/packages/bytebot-ui/src/components/ui/pagination.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft02Icon, ArrowRight02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "./button";
+import { cn } from "@/lib/utils";
 
 interface PaginationProps {
   currentPage: number;
@@ -56,18 +57,18 @@ export const Pagination: React.FC<PaginationProps> = ({
   const visiblePages = getVisiblePages();
 
   return (
-    <div className="flex items-center justify-between border-t border-bytebot-bronze-light-7 pt-6">
-      <div className="flex items-center text-sm text-bytebot-bronze-light-11">
+    <div className="flex items-center justify-between border-t border-border pt-6">
+      <div className="flex items-center text-sm text-muted-foreground">
         Showing {startItem} to {endItem} of {total} results
       </div>
-      
+
       <div className="flex items-center space-x-2">
         <Button
           variant="outline"
           size="sm"
           onClick={() => onPageChange(currentPage - 1)}
           disabled={currentPage === 1}
-          className="flex items-center space-x-1"
+          className="flex items-center space-x-1 border-border text-muted-foreground hover:text-foreground"
         >
           <HugeiconsIcon icon={ArrowLeft02Icon} className="h-4 w-4" />
           <span>Previous</span>
@@ -79,7 +80,7 @@ export const Pagination: React.FC<PaginationProps> = ({
               return (
                 <span
                   key={`ellipsis-${index}`}
-                  className="px-3 py-2 text-sm text-bytebot-bronze-light-11"
+                  className="px-3 py-2 text-sm text-muted-foreground"
                 >
                   ...
                 </span>
@@ -95,11 +96,12 @@ export const Pagination: React.FC<PaginationProps> = ({
                 variant={isCurrentPage ? "default" : "outline"}
                 size="sm"
                 onClick={() => onPageChange(pageNum)}
-                className={`min-w-[40px] ${
+                className={cn(
+                  "min-w-[40px]",
                   isCurrentPage
-                    ? "bg-bytebot-bronze-dark-7 text-white"
-                    : "text-bytebot-bronze-light-11 hover:text-bytebot-bronze-dark-7"
-                }`}
+                    ? "bg-primary text-primary-foreground"
+                    : "border-border text-muted-foreground hover:text-foreground"
+                )}
               >
                 {pageNum}
               </Button>
@@ -112,7 +114,7 @@ export const Pagination: React.FC<PaginationProps> = ({
           size="sm"
           onClick={() => onPageChange(currentPage + 1)}
           disabled={currentPage === totalPages}
-          className="flex items-center space-x-1"
+          className="flex items-center space-x-1 border-border text-muted-foreground hover:text-foreground"
         >
           <span>Next</span>
           <HugeiconsIcon icon={ArrowRight02Icon} className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- update task list item styling to use semantic theme tokens and improve status icon colors
- refresh task tab appearance so labels, counters, and borders react to light/dark themes
- apply theme-aware colors to task loading/empty states and pagination controls

## Testing
- npm run lint --prefix packages/bytebot-ui *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d014ab0fbc8323aca96c89c1daf29f