### PR TITLE
Align background tokens

### DIFF
--- a/packages/bytebot-ui/src/app/globals.css
+++ b/packages/bytebot-ui/src/app/globals.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --color-background: var(--color-bytebot-bronze-light-4);
+  --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
@@ -167,7 +167,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: var(--color-bytebot-bronze-light-4);
   --foreground: oklch(0.147 0.004 49.25);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.147 0.004 49.25);


### PR DESCRIPTION
## Summary
- update the Tailwind theme background token to reference the shared `--background` CSS variable
- configure the light theme's `--background` to use the bronze light surface while keeping the dark override intact

## Testing
- npm run dev *(fails: tsx not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0184466948323970efcd747d97676