### PR TITLE
Build agent prompts at runtime

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.constants.ts
@@ -15,10 +15,16 @@ Focus on:
 
 Provide a structured summary that can be used as context for continuing the task.`;
 
-export const AGENT_SYSTEM_PROMPT = `
+export const buildAgentSystemPrompt = (): string => {
+  const now = new Date();
+  const currentDate = now.toLocaleDateString();
+  const currentTime = now.toLocaleTimeString();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  return `
 You are **Bytebot**, a highly‑reliable AI engineer operating a virtual computer with dynamic resolution.
 
-The current date is ${new Date().toLocaleDateString()}. The current time is ${new Date().toLocaleTimeString()}. The current timezone is ${Intl.DateTimeFormat().resolvedOptions().timeZone}.
+The current date is ${currentDate}. The current time is ${currentTime}. The current timezone is ${timeZone}.
 
 ────────────────────────
 AVAILABLE APPLICATIONS
@@ -36,12 +42,12 @@ Trash -- The default trash
 
 ALL APPLICATIONS ARE GUI BASED, USE THE COMPUTER TOOLS TO INTERACT WITH THEM. ONLY ACCESS THE APPLICATIONS VIA THEIR DESKTOP ICONS.
 
-*Never* use keyboard shortcuts to switch between applications, only use \`computer_application\` to switch between the default applications. 
+*Never* use keyboard shortcuts to switch between applications, only use \`computer_application\` to switch between the default applications.
 
 ────────────────────────
 CORE WORKING PRINCIPLES
 ────────────────────────
-1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document. 
+1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document.
    - When screen size matters, call \`computer_screen_info\` to know exact dimensions.
 
 **COORDINATE GRID SYSTEM**: Screenshots may include a coordinate grid overlay with:
@@ -220,7 +226,8 @@ T, Tab,
 U, Up,  
 V, W, X, Y, Z
 
-Remember: **accuracy over speed, clarity and consistency over cleverness**.  
+Remember: **accuracy over speed, clarity and consistency over cleverness**.
 
 **For repetitive tasks**: Persistence is key. Continue until ALL items are processed, not just the first few.
 `;
+};

--- a/packages/bytebot-agent-cc/src/agent/agent.processor.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.processor.ts
@@ -33,7 +33,7 @@ import {
   BytebotAgentResponse,
 } from './agent.types';
 import {
-  AGENT_SYSTEM_PROMPT,
+  buildAgentSystemPrompt,
   SUMMARIZATION_SYSTEM_PROMPT,
 } from './agent.constants';
 import { query } from '@anthropic-ai/claude-code';
@@ -187,7 +187,7 @@ export class AgentProcessor {
         prompt: task.description,
         options: {
           abortController: this.abortController,
-          appendSystemPrompt: AGENT_SYSTEM_PROMPT,
+          appendSystemPrompt: buildAgentSystemPrompt(),
           permissionMode: 'bypassPermissions',
           mcpServers: {
             desktop: {

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -16,10 +16,16 @@ Focus on:
 
 Provide a structured summary that can be used as context for continuing the task.`;
 
-export const AGENT_SYSTEM_PROMPT = `
+export const buildAgentSystemPrompt = (): string => {
+  const now = new Date();
+  const currentDate = now.toLocaleDateString();
+  const currentTime = now.toLocaleTimeString();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  return `
 You are **Bytebot**, a meticulous AI engineer operating a dynamic-resolution workstation.
 
-Current date: ${new Date().toLocaleDateString()}. Current time: ${new Date().toLocaleTimeString()}. Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}.
+Current date: ${currentDate}. Current time: ${currentTime}. Timezone: ${timeZone}.
 
 ════════════════════════════════
 WORKSTATION SNAPSHOT
@@ -119,3 +125,4 @@ ADDITIONAL GUIDANCE
 Accuracy outranks speed. Think aloud, justify every coordinate, and keep the audit trail obvious.
 
 `;
+};

--- a/packages/bytebot-agent/src/agent/agent.processor.ts
+++ b/packages/bytebot-agent/src/agent/agent.processor.ts
@@ -33,7 +33,7 @@ import {
   BytebotAgentResponse,
 } from './agent.types';
 import {
-  AGENT_SYSTEM_PROMPT,
+  buildAgentSystemPrompt,
   SUMMARIZATION_SYSTEM_PROMPT,
 } from './agent.constants';
 import { SummariesService } from '../summaries/summaries.service';
@@ -199,7 +199,7 @@ export class AgentProcessor {
       }
 
       agentResponse = await service.generateMessage(
-        AGENT_SYSTEM_PROMPT,
+        buildAgentSystemPrompt(),
         messages,
         model.name,
         true,


### PR DESCRIPTION
## Summary
- replace the static Bytebot system prompt constant with a builder that embeds the current date, time, and timezone at call time
- update both the standard and Claude Code agent processors to generate the prompt dynamically before requesting model output

## Testing
- `npm run lint --prefix packages/bytebot-agent` *(fails: existing lint violations in unrelated files)*
- `npm run lint --prefix packages/bytebot-agent-cc` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d01f86b2ac8323b78063e762821439