### PR TITLE
Emphasize efficient planning in agent guidance

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.constants.ts
@@ -43,6 +43,7 @@ CORE WORKING PRINCIPLES
 ────────────────────────
 1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document.
    - When screen size matters, call \`computer_screen_info\` to know exact dimensions.
+   - Before planning any action, perform an exhaustive observation: enumerate the key UI regions and their contents, summarise prominent visible text, list interactive elements (buttons, fields, toggles, menus), note any alerts/modals/system notifications, and highlight differences from the previous screenshot.
    - Before executing, articulate a compact action plan that minimizes tool invocations. Skip redundant calls when existing context already contains the needed details.
 
 **COORDINATE GRID SYSTEM**: Screenshots may include a coordinate grid overlay with:

--- a/packages/bytebot-agent-cc/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.constants.ts
@@ -41,8 +41,9 @@ ALL APPLICATIONS ARE GUI BASED, USE THE COMPUTER TOOLS TO INTERACT WITH THEM. ON
 ────────────────────────
 CORE WORKING PRINCIPLES
 ────────────────────────
-1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document. 
+1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document.
    - When screen size matters, call \`computer_screen_info\` to know exact dimensions.
+   - Before executing, articulate a compact action plan that minimizes tool invocations. Skip redundant calls when existing context already contains the needed details.
 
 **COORDINATE GRID SYSTEM**: Screenshots may include a coordinate grid overlay with:
    • **Grid lines** every 100 pixels for precise positioning

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -33,6 +33,7 @@ OPERATING PRINCIPLES
 1. Observe → Plan → Act → Verify
    - Begin every task with computer_screenshot and capture a fresh view after any UI change.
    - Describe what you see, outline the next step, execute, then confirm the result with another screenshot when needed.
+   - Before executing, articulate a compact action plan that minimizes tool invocations. Skip redundant calls when existing context already contains the needed details.
    - When screen size matters, call computer_screen_info to know exact dimensions.
 2. Exploit the Coordinate Grids
    - Full-screen overlays show 100 px green grids; focused captures show 25–50 px cyan grids with global labels.
@@ -101,6 +102,7 @@ STANDARD LOOP
 1. Prepare – Screenshot → describe state → draft plan.
 2. Target – Attempt keyboard navigation first; if visual targeting is required, analyse grid → request focused/zoomed captures → compute/request coordinates → act.
 3. Verify – Capture confirmation screenshot when outcomes matter.
+   - Revisit your compact plan after each verification step and only issue new tool calls when that plan requires them.
 4. Batch Work – Process items in small batches (≈10–20), track progress, and continue until the queue is exhausted or instructions change.
 5. Document – Keep succinct notes about key actions, decisions, and open issues.
 6. Clean Up – Close applications you opened, return to the desktop, then call set_task_status when the objective is met.


### PR DESCRIPTION
## Summary
- require Bytebot to announce a compact plan that minimizes tool calls before acting when operating principles are followed
- remind the standard loop to revisit that plan after verification and avoid unnecessary tool usage
- propagate the same planning-and-efficiency guidance to the cc agent prompts for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0205b56f083238c53c807255e4e3d