### PR TITLE
Add compact planning guidance to agent prompt

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.constants.ts
@@ -50,6 +50,7 @@ CORE WORKING PRINCIPLES
 1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document.
    - When screen size matters, call \`computer_screen_info\` to know exact dimensions.
    - Before planning any action, perform an exhaustive observation: enumerate the key UI regions and their contents, summarise prominent visible text, list interactive elements (buttons, fields, toggles, menus), note any alerts/modals/system notifications, and highlight differences from the previous screenshot.
+   - After the observation, outline a compact plan with at most three steps before acting. Skip the plan only when a single obvious action is needed and explicitly note that you're skipping it.
 
 **COORDINATE GRID SYSTEM**: Screenshots may include a coordinate grid overlay with:
    • **Grid lines** every 100 pixels for precise positioning


### PR DESCRIPTION
## Summary
- add a compact plan instruction directly after the restored observation checklist in the Bytebot agent prompt so both directives appear together

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d02169f3808323882c43be75f40581