### PR TITLE
Handle telemetry reset session body input

### DIFF
--- a/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
@@ -1,0 +1,17 @@
+import { TelemetryController } from './telemetry.controller';
+import { TelemetryService } from './telemetry.service';
+
+describe('TelemetryController', () => {
+  it('passes trimmed session from request body to resetAll', async () => {
+    const resetAll = jest.fn().mockResolvedValue(undefined);
+    const telemetry = {
+      resetAll,
+    } as unknown as TelemetryService;
+
+    const controller = new TelemetryController(telemetry);
+
+    await controller.reset(undefined, '  session-from-body  ');
+
+    expect(resetAll).toHaveBeenCalledWith('session-from-body');
+  });
+});

--- a/packages/bytebotd/src/telemetry/telemetry.controller.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.ts
@@ -145,8 +145,12 @@ export class TelemetryController {
   }
 
   @Post('reset')
-  async reset(@Query('session') sessionId?: string) {
-    const targetSession = sessionId?.trim();
+  async reset(
+    @Query('session') sessionId?: string,
+    @Body('session') bodySessionId?: string,
+  ) {
+    const rawSession = sessionId ?? bodySessionId;
+    const targetSession = rawSession?.trim();
     await this.telemetry.resetAll(targetSession || undefined);
     return { ok: true };
   }


### PR DESCRIPTION
## Summary
- allow telemetry reset endpoint to accept a session id from either the query string or request body and trim it before resetting telemetry
- add a controller test to cover the new body-based session id path

## Testing
- npm test --prefix packages/bytebotd

------
https://chatgpt.com/codex/tasks/task_e_68d03514c6108323a3b2193f1720e4a0