### PR TITLE
Add smart click task id to telemetry context

### DIFF
--- a/packages/bytebot-agent/src/agent/smart-click.helper.ts
+++ b/packages/bytebot-agent/src/agent/smart-click.helper.ts
@@ -106,14 +106,21 @@ export class SmartClickHelper {
     this.ensureDirectory(this.progressDir);
   }
 
-  private async emitTelemetryEvent(type: string, data: Record<string, any> = {}): Promise<void> {
+  private async emitTelemetryEvent(
+    type: string,
+    data: Record<string, any> = {},
+  ): Promise<void> {
     try {
       const base = process.env.BYTEBOT_DESKTOP_BASE_URL;
       if (!base) return;
+      const payload =
+        type === 'smart_click_complete' && this.currentTaskId
+          ? { clickTaskId: this.currentTaskId, ...data }
+          : data;
       await fetch(`${base}/telemetry/event`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type, ...data }),
+        body: JSON.stringify({ type, ...payload }),
       });
     } catch {
       // ignore

--- a/packages/bytebotd/src/computer-use/computer-use.service.ts
+++ b/packages/bytebotd/src/computer-use/computer-use.service.ts
@@ -398,6 +398,7 @@ export class ComputerUseService {
       zoomLevel: context?.zoomLevel,
       targetDescription: context?.targetDescription ?? description,
       source: context?.source ?? 'manual',
+      clickTaskId: context?.clickTaskId,
     };
 
     if (targetCoordinates) {


### PR DESCRIPTION
## Summary
- include the click task identifier in the telemetry context used when recording clicks
- ensure smart click completion events always forward the active task identifier to the telemetry service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0352f02d08323bd3e80508e567c55