### PR TITLE
Forward smart click task ids in telemetry

### DIFF
--- a/packages/bytebotd/src/computer-use/computer-use.service.ts
+++ b/packages/bytebotd/src/computer-use/computer-use.service.ts
@@ -14,6 +14,7 @@ import {
   ComputerAction,
   MoveMouseAction,
   TraceMouseAction,
+  ClickContext,
   ClickMouseAction,
   PressMouseAction,
   DragMouseAction,
@@ -399,12 +400,14 @@ export class ComputerUseService {
     await this.delay(this.calibrationDelayMs);
     const actualPointer = await this.nutService.getCursorPosition();
 
-    const telemetryContext = {
+    const clickTaskId = context?.clickTaskId;
+
+    const telemetryContext: ClickContext = {
       region: context?.region,
       zoomLevel: context?.zoomLevel,
       targetDescription: context?.targetDescription ?? description,
       source: context?.source ?? 'manual',
-      clickTaskId: context?.clickTaskId,
+      clickTaskId,
     };
 
     const finalTarget = destination ?? targetCoordinates;
@@ -422,7 +425,7 @@ export class ComputerUseService {
         target: targetCoordinates ?? undefined,
         adjusted: destination ?? undefined,
         actual: actualPointer,
-        clickTaskId: context?.clickTaskId,
+        clickTaskId,
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure click telemetry context forwards the originating smart-click task id for all click records
- include the task identifier in smart-click completion telemetry payloads for easier correlation in logs and UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d036a9333483239e936340d63c0655