### PR TITLE
Add dark mode styling for chat container surfaces

### DIFF
--- a/packages/bytebot-ui/src/components/messages/ChatContainer.tsx
+++ b/packages/bytebot-ui/src/components/messages/ChatContainer.tsx
@@ -81,9 +81,9 @@ export function ChatContainer({
   };
 
   return (
-    <div className="bg-bytebot-bronze-light-3 flex h-full flex-col">
+    <div className="bg-bytebot-bronze-light-3 dark:bg-bytebot-bronze-dark-3 flex h-full flex-col">
       {isLoadingSession ? (
-        <div className="bg-bytebot-bronze-light-3 border-bytebot-bronze-light-7 flex h-full min-h-80 items-center justify-center overflow-hidden rounded-lg border">
+        <div className="bg-bytebot-bronze-light-3 dark:bg-bytebot-bronze-dark-3 border-bytebot-bronze-light-7 dark:border-bytebot-bronze-dark-7 flex h-full min-h-80 items-center justify-center overflow-hidden rounded-lg border">
           <Loader size={32} />
         </div>
       ) : groupedMessages.length > 0 ? (
@@ -102,7 +102,7 @@ export function ChatContainer({
 
             {taskStatus === TaskStatus.RUNNING &&
               control === Role.ASSISTANT && (
-                <div className="bg-bytebot-bronze-light-3 border-bytebot-bronze-light-7 flex items-center justify-start gap-4 border-x px-4 py-3">
+                <div className="bg-bytebot-bronze-light-3 dark:bg-bytebot-bronze-dark-3 border-bytebot-bronze-light-7 dark:border-bytebot-bronze-dark-7 flex items-center justify-start gap-4 border-x px-4 py-3">
                   <MessageAvatar role={Role.ASSISTANT} />
                   <div className="flex items-center justify-start gap-2">
                     <div className="flex h-full items-center justify-center py-2">
@@ -128,9 +128,9 @@ export function ChatContainer({
 
           {/* Fixed chat input at bottom */}
           {[TaskStatus.RUNNING, TaskStatus.NEEDS_HELP].includes(taskStatus) && (
-            <div className="bg-bytebot-bronze-light-3 z-10 flex-shrink-0">
-              <div className="border-bytebot-bronze-light-7 rounded-b-lg border-x border-b p-2">
-                <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-7 rounded-lg border p-2">
+            <div className="bg-bytebot-bronze-light-3 dark:bg-bytebot-bronze-dark-3 z-10 flex-shrink-0">
+              <div className="border-bytebot-bronze-light-7 dark:border-bytebot-bronze-dark-7 rounded-b-lg border-x border-b p-2">
+                <div className="bg-bytebot-bronze-light-2 dark:bg-bytebot-bronze-dark-2 border-bytebot-bronze-light-7 dark:border-bytebot-bronze-dark-7 rounded-lg border p-2">
                   <ChatInput
                     input={input}
                     isLoading={isLoading}


### PR DESCRIPTION
## Summary
- add dark theme backgrounds and borders for the chat container wrapper and assistant status strip
- extend chat input shell with matching dark mode tokens to maintain contrast in darker theme
- ensure loading and status rows use the same dark palette overrides for visual consistency

## Testing
- npm run lint *(fails: next not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d03cc9a72c8323b4a5ba6b110a0ea7