### PR TITLE
Align conversation UI with theme tokens

### DIFF
--- a/packages/bytebot-ui/src/components/messages/AssistantMessage.tsx
+++ b/packages/bytebot-ui/src/components/messages/AssistantMessage.tsx
@@ -18,16 +18,20 @@ export function AssistantMessage({
   messageIdToIndex,
 }: AssistantMessageProps) {
   return (
-    <div className={
-      cn(
-        "bg-bytebot-bronze-light-3 flex items-start justify-start gap-2 px-4 py-3 border-x border-bytebot-bronze-light-7",
-        ![TaskStatus.RUNNING, TaskStatus.NEEDS_HELP].includes(taskStatus) && !group.take_over && "border-b border-bytebot-bronze-light-7 rounded-b-lg"
-      )}
+    <div
+      className={
+        cn(
+          "flex items-start justify-start gap-2 border-x border-border bg-card px-4 py-3 text-card-foreground",
+          ![TaskStatus.RUNNING, TaskStatus.NEEDS_HELP].includes(taskStatus) &&
+            !group.take_over &&
+            "border-b border-border rounded-b-lg"
+        )
+      }
     >
       <MessageAvatar role={group.role} />
 
       {group.take_over ? (
-        <div className="border-bytebot-bronze-light-a6 bg-bytebot-bronze-light-a1 w-full rounded-2xl border p-2">
+        <div className="w-full rounded-2xl border border-border bg-card p-2">
           <div className="flex items-center gap-2">
             <Image
               src="/indicators/indicator-pink.png"
@@ -35,11 +39,11 @@ export function AssistantMessage({
               width={15}
               height={15}
             />
-            <p className="text-bytebot-bronze-light-12 text-[12px] font-medium">
+            <p className="text-[12px] font-medium text-card-foreground">
               You took control
             </p>
           </div>
-          <div className="bg-bytebot-bronze-light-2 mt-2 space-y-0.5 rounded-2xl p-1">
+          <div className="mt-2 space-y-0.5 rounded-2xl border border-border/60 bg-muted/60 p-1">
             {group.messages.map((message) => (
               <div
                 key={message.id}

--- a/packages/bytebot-ui/src/components/messages/MessageAvatar.tsx
+++ b/packages/bytebot-ui/src/components/messages/MessageAvatar.tsx
@@ -9,7 +9,8 @@ interface MessageAvatarProps {
 }
 
 export function MessageAvatar({ role }: MessageAvatarProps) {
-  const baseClasses = "flex flex-shrink-0 items-center justify-center rounded-md border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-1 h-[28px] w-[28px]";
+  const baseClasses =
+    "flex h-[28px] w-[28px] flex-shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground";
 
   if (role === Role.ASSISTANT) {
     return (
@@ -29,7 +30,7 @@ export function MessageAvatar({ role }: MessageAvatarProps) {
     <div className={baseClasses}>
       <HugeiconsIcon
         icon={User03Icon}
-        className="text-bytebot-bronze-dark-9 w-4 h-4"
+        className="h-4 w-4"
       />
     </div>
   );

--- a/packages/bytebot-ui/src/components/messages/UserMessage.tsx
+++ b/packages/bytebot-ui/src/components/messages/UserMessage.tsx
@@ -16,8 +16,8 @@ interface UserMessageProps {
 export function UserMessage({ group, messageIdToIndex }: UserMessageProps) {
   if (messageIdToIndex[group.messages[0].id] === 0) {
     return (
-      <div className="sticky top-0 z-10 bg-bytebot-bronze-light-4">
-        <div className="border-bytebot-bronze-light-7 flex items-start justify-start gap-2 border px-4 py-3 bg-bytebot-bronze-light-2 rounded-t-lg">
+      <div className="sticky top-0 z-10 bg-background">
+        <div className="flex items-start justify-start gap-2 rounded-t-lg border border-border bg-card px-4 py-3 text-card-foreground">
           <MessageAvatar role={group.role} />
 
           <div>
@@ -57,11 +57,11 @@ export function UserMessage({ group, messageIdToIndex }: UserMessageProps) {
                   }
                   return null;
                 })}
-                <div className="bg-bytebot-bronze-light-4 space-y-2 rounded-md px-2 py-1">
+                <div className="space-y-2 rounded-md bg-muted/60 px-2 py-1">
                   {message.content.map((block, index) => (
                     <div
                       key={index}
-                      className="text-bytebot-bronze-light-12 text-sm"
+                      className="text-sm text-card-foreground"
                     >
                       {isTextContentBlock(block) && (
                         <ReactMarkdown>{block.text}</ReactMarkdown>
@@ -78,7 +78,7 @@ export function UserMessage({ group, messageIdToIndex }: UserMessageProps) {
   }
 
   return (
-    <div className="bg-bytebot-bronze-light-3 flex items-start justify-end gap-2 px-4 py-3 border-x border-bytebot-bronze-light-7">
+    <div className="flex items-start justify-end gap-2 border-x border-border bg-card px-4 py-3 text-card-foreground">
       <div>
         {group.messages.map((message) => (
           <div
@@ -116,9 +116,9 @@ export function UserMessage({ group, messageIdToIndex }: UserMessageProps) {
               }
               return null;
             })}
-            <div className="space-y-2 rounded-md text-fuchsia-600">
+            <div className="space-y-2 rounded-md bg-muted/60 p-2 text-card-foreground">
               {message.content.map((block, index) => (
-                <div key={index} className="prose prose-sm max-w-none text-sm">
+                <div key={index} className="prose prose-sm max-w-none text-sm text-card-foreground">
                   {isTextContentBlock(block) && (
                     <ReactMarkdown>{block.text}</ReactMarkdown>
                   )}

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolContentNormal.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolContentNormal.tsx
@@ -30,7 +30,7 @@ const applicationMap: Record<Application, string> = {
 
 function ToolDetailsNormal({ block }: { block: ComputerToolUseContentBlock }) {
   const baseClasses =
-    "px-1 py-0.5 text-[12px] text-bytebot-bronze-light-11 bg-bytebot-red-light-1 border border-bytebot-bronze-light-7 rounded-md";
+    "rounded-md border border-border bg-muted px-1 py-0.5 text-[12px] text-muted-foreground";
 
   return (
     <>
@@ -106,12 +106,12 @@ export function ComputerToolContentNormal({
 
   return (
     <div className="mb-3 max-w-4/5">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 text-muted-foreground">
         <HugeiconsIcon
           icon={getIcon(block)}
-          className="text-bytebot-bronze-dark-9 h-4 w-4"
+          className="h-4 w-4"
         />
-        <p className="text-bytebot-bronze-light-11 text-xs">
+        <p className="text-xs">
           {getLabel(block)}
         </p>
         <ToolDetailsNormal block={block} />

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolContentTakeOver.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolContentTakeOver.tsx
@@ -15,7 +15,8 @@ interface ComputerToolContentTakeOverProps {
 }
 
 function ToolDetailsTakeOver({ block }: { block: ComputerToolUseContentBlock }) {
-  const baseClasses = "px-1 py-0.5 text-xs text-fuchsia-600 bg-bytebot-red-light-1 border border-bytebot-bronze-light-7 rounded-md";
+  const baseClasses =
+    "rounded-md border border-border bg-muted px-1 py-0.5 text-xs text-primary";
 
   return (
     <>
@@ -83,14 +84,14 @@ export function ComputerToolContentTakeOver({ block }: ComputerToolContentTakeOv
 
   return (
     <div className="max-w-4/5">
-      <div className="flex items-center justify-start gap-2">
-        <div className="w-7 h-7 flex items-center justify-center">
+      <div className="flex items-center justify-start gap-2 text-muted-foreground">
+        <div className="flex h-7 w-7 items-center justify-center text-primary">
           <HugeiconsIcon
             icon={getIcon(block)}
-            className="h-4 w-4 text-fuchsia-600"
+            className="h-4 w-4"
           />
         </div>
-        <p className="text-xs text-bytebot-bronze-light-11">
+        <p className="text-xs">
           {getLabel(block)}
         </p>
         <ToolDetailsTakeOver block={block} />

--- a/packages/bytebot-ui/src/components/messages/content/ErrorContent.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ErrorContent.tsx
@@ -9,13 +9,13 @@ interface ErrorContentProps {
 
 export function ErrorContent({ block }: ErrorContentProps) {
   return (
-    <div className="mb-3 rounded-md border border-red-200 bg-red-100 p-2">
+    <div className="mb-3 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-destructive">
       <div className="flex items-center justify-start gap-2">
         <HugeiconsIcon
           icon={AlertCircleIcon}
-          className="h-5 w-5 text-red-800"
+          className="h-5 w-5"
         />
-        <div className="prose prose-sm max-w-none text-sm text-red-800">
+        <div className="prose prose-sm max-w-none text-sm text-destructive">
           {isTextContentBlock(block.content?.[0])
             ? block.content?.[0].text
             : "Error running tool"}

--- a/packages/bytebot-ui/src/components/messages/content/ImageContent.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ImageContent.tsx
@@ -13,17 +13,17 @@ export function ImageContent({ block }: ImageContentProps) {
   const width = 250;
   const height = 250;
   return (
-    <div className="max-w-4/5 mb-3">
-      <div className="flex items-center gap-2 mb-2">
+    <div className="mb-3 max-w-4/5">
+      <div className="mb-2 flex items-center gap-2 text-muted-foreground">
         <HugeiconsIcon
           icon={Camera01Icon}
-          className="text-bytebot-bronze-dark-9 h-4 w-4"
+          className="h-4 w-4"
         />
-        <p className="text-bytebot-bronze-light-11 text-xs">
+        <p className="text-xs">
           Screenshot taken
         </p>
       </div>
-      <div className="border border-bytebot-bronze-light-7 rounded-md overflow-hidden inline-block">
+      <div className="inline-block overflow-hidden rounded-md border border-border">
         <Image
           src={`data:image/png;base64,${block.source.data}`}
           alt="Screenshot"

--- a/packages/bytebot-ui/src/components/messages/content/TextContent.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/TextContent.tsx
@@ -9,36 +9,36 @@ interface TextContentProps {
 export function TextContent({ block }: TextContentProps) {
   return (
     <div className="mb-3">
-      <div className="text-bytebot-bronze-dark-8 prose prose-sm max-w-none text-sm">
+      <div className="prose prose-sm max-w-none text-sm text-card-foreground">
         <ReactMarkdown
           components={{
             h1: ({ children }) => (
-              <h1 className="text-bytebot-bronze-dark-9 mt-4 mb-2 text-base font-semibold">
+              <h1 className="mt-4 mb-2 text-base font-semibold text-card-foreground">
                 {children}
               </h1>
             ),
             h2: ({ children }) => (
-              <h2 className="text-bytebot-bronze-dark-9 mt-3 mb-2 text-sm font-semibold">
+              <h2 className="mt-3 mb-2 text-sm font-semibold text-card-foreground">
                 {children}
               </h2>
             ),
             h3: ({ children }) => (
-              <h3 className="text-bytebot-bronze-dark-9 mt-3 mb-1 text-sm font-medium">
+              <h3 className="mt-3 mb-1 text-sm font-medium text-card-foreground">
                 {children}
               </h3>
             ),
             h4: ({ children }) => (
-              <h4 className="text-bytebot-bronze-dark-8 mt-2 mb-1 text-sm font-medium">
+              <h4 className="mt-2 mb-1 text-sm font-medium text-card-foreground">
                 {children}
               </h4>
             ),
             h5: ({ children }) => (
-              <h5 className="text-bytebot-bronze-dark-8 mt-2 mb-1 text-xs font-medium">
+              <h5 className="mt-2 mb-1 text-xs font-medium text-card-foreground">
                 {children}
               </h5>
             ),
             h6: ({ children }) => (
-              <h6 className="text-bytebot-bronze-dark-8 mt-2 mb-1 text-xs font-medium">
+              <h6 className="mt-2 mb-1 text-xs font-medium text-card-foreground">
                 {children}
               </h6>
             ),
@@ -61,41 +61,41 @@ export function TextContent({ block }: TextContentProps) {
               </li>
             ),
             blockquote: ({ children }) => (
-              <blockquote className="border-bytebot-bronze-light-7 text-bytebot-bronze-dark-7 mb-2 border-l-4 pl-4 italic">
+              <blockquote className="mb-2 border-l-4 border-border pl-4 italic text-muted-foreground">
                 {children}
               </blockquote>
             ),
             code: ({ children, className }) => {
               const isInline = !className;
               return isInline ? (
-                <code className="text-bytebot-bronze-dark-9 rounded px-1 py-0.5 font-mono text-xs">
+                <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs text-card-foreground">
                   {children}
                 </code>
               ) : (
-                <code className="text-bytebot-bronze-dark-9 block overflow-x-auto rounded p-3 font-mono text-xs whitespace-pre-wrap">
+                <code className="block overflow-x-auto rounded bg-muted p-3 font-mono text-xs text-card-foreground whitespace-pre-wrap">
                   {children}
                 </code>
               );
             },
             pre: ({ children }) => (
-              <pre className="mb-2 overflow-x-auto rounded border p-3">
+              <pre className="mb-2 overflow-x-auto rounded border border-border bg-muted p-3">
                 {children}
               </pre>
             ),
             strong: ({ children }) => (
-              <strong className="text-bytebot-bronze-dark-9 font-semibold">
+              <strong className="font-semibold text-card-foreground">
                 {children}
               </strong>
             ),
             em: ({ children }) => (
-              <em className="text-bytebot-bronze-dark-8 italic">
+              <em className="italic text-muted-foreground">
                 {children}
               </em>
             ),
             a: ({ children, href }) => (
               <a
                 href={href}
-                className="text-blue-600 underline hover:text-blue-800"
+                className="text-primary underline hover:text-primary/80"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## Summary
- replace assistant and user message containers with theme token backgrounds and borders so conversation bubbles honor dark mode
- refresh message avatars and markdown rendering to rely on shared card and muted tokens instead of bronze-only colors
- update tool, screenshot, and error content wrappers to use neutral/dark-aware borders and accents

## Testing
- npm run lint --prefix packages/bytebot-ui *(fails: `next` binary unavailable because dependencies could not be installed in the container)*
- npm install --prefix packages/bytebot-ui *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03fc3247c8323969c055957843b4d