### PR TITLE
Persist model selection across sessions

### DIFF
--- a/packages/bytebot-ui/package.json
+++ b/packages/bytebot-ui/package.json
@@ -7,7 +7,7 @@
     "build": "npm run build --prefix ../shared && next build",
     "start": "npm run build --prefix ../shared && tsx server.ts",
     "lint": "next lint",
-    "test": "tsx --test src/components/tasks/__tests__/TaskItem.test.tsx"
+    "test": "tsx --test \"src/**/*.test.ts\" \"src/**/*.test.tsx\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/bytebot-ui/src/app/__tests__/modelStorage.test.ts
+++ b/packages/bytebot-ui/src/app/__tests__/modelStorage.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { selectInitialModel } from "../modelStorage";
+
+const models = [
+  { name: "model-a", title: "Model A" },
+  { name: "model-b", title: "Model B" },
+];
+
+describe("selectInitialModel", () => {
+  it("returns the stored model when it exists", () => {
+    const result = selectInitialModel(models, "model-b");
+    assert.equal(result, models[1]);
+  });
+
+  it("falls back to the first model when stored name is missing", () => {
+    const result = selectInitialModel(models, "model-c");
+    assert.equal(result, models[0]);
+  });
+
+  it("returns null when there are no models", () => {
+    const result = selectInitialModel([], "model-a");
+    assert.equal(result, null);
+  });
+});

--- a/packages/bytebot-ui/src/app/modelStorage.ts
+++ b/packages/bytebot-ui/src/app/modelStorage.ts
@@ -1,0 +1,19 @@
+import { Model } from "@/types";
+
+export const MODEL_STORAGE_KEY = "selectedModelName";
+
+export function selectInitialModel(
+  models: Model[],
+  storedName?: string | null,
+): Model | null {
+  if (models.length === 0) {
+    return null;
+  }
+
+  if (!storedName) {
+    return models[0];
+  }
+
+  const match = models.find((model) => model.name === storedName);
+  return match ?? models[0];
+}


### PR DESCRIPTION
## Summary
- load the previously selected model from localStorage when fetching the models list
- persist model choices through a shared helper used by the selector and task creation
- cover the initial-selection fallback logic with a small node:test unit test and expand the test script glob

## Testing
- npm test *(fails: tsx executable missing because npm install is blocked by registry 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d041f6987c8323b12171dd579026e1