### PR TITLE
Adjust task page active model banner theming

### DIFF
--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -136,15 +136,15 @@ export default function TaskPage() {
       <Header />
 
       <main className="m-2 flex-1 overflow-hidden px-2 py-4">
-        <div className="mb-4 flex flex-col gap-1 rounded-lg border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-2 px-4 py-3">
-          <span className="text-xs font-semibold uppercase tracking-wide text-bytebot-bronze-light-11">
+        <div className="mb-4 flex flex-col gap-1 rounded-lg border border-border bg-card px-4 py-3 dark:border-border/60 dark:bg-muted">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Active Model
           </span>
-          <span className="text-sm font-semibold text-bytebot-bronze-dark-7">
+          <span className="text-sm font-semibold text-foreground">
             {modelIdentifier || "Model unavailable"}
           </span>
           {modelNameDetails && (
-            <span className="text-xs text-bytebot-bronze-light-10">
+            <span className="text-xs text-muted-foreground">
               Identifier: {modelNameDetails}
             </span>
           )}


### PR DESCRIPTION
## Summary
- replace the task detail page active model banner styling with neutral card and foreground tokens
- align supporting labels with the shared muted foreground palette for consistency across color modes

## Testing
- npm run lint *(fails: Next.js binaries unavailable because npm install is blocked by 403 from registry)*


------
https://chatgpt.com/codex/tasks/task_e_68d044d2f444832398b94307cc72ca3c