### PR TITLE
Nest active model banner within desktop column

### DIFF
--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -136,22 +136,22 @@ export default function TaskPage() {
       <Header />
 
       <main className="m-2 flex-1 overflow-hidden px-2 py-4">
-        <div className="mb-4 flex flex-col gap-1 rounded-lg border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-2 px-4 py-3">
-          <span className="text-xs font-semibold uppercase tracking-wide text-bytebot-bronze-light-11">
-            Active Model
-          </span>
-          <span className="text-sm font-semibold text-bytebot-bronze-dark-7">
-            {modelIdentifier || "Model unavailable"}
-          </span>
-          {modelNameDetails && (
-            <span className="text-xs text-bytebot-bronze-light-10">
-              Identifier: {modelNameDetails}
-            </span>
-          )}
-        </div>
         <div className="grid h-full grid-cols-7 gap-4">
           {/* Main container */}
           <div className="col-span-4 flex flex-col gap-3">
+            <div className="flex flex-col gap-1 rounded-lg border border-bytebot-bronze-light-7 bg-bytebot-bronze-light-2 px-4 py-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-bytebot-bronze-light-11">
+                Active Model
+              </span>
+              <span className="text-sm font-semibold text-bytebot-bronze-dark-7">
+                {modelIdentifier || "Model unavailable"}
+              </span>
+              {modelNameDetails && (
+                <span className="text-xs text-bytebot-bronze-light-10">
+                  Identifier: {modelNameDetails}
+                </span>
+              )}
+            </div>
             <DesktopContainer
               screenshot={taskInactive ? currentScreenshot : null}
               viewOnly={vncViewOnly()}


### PR DESCRIPTION
## Summary
- move the Active Model banner into the desktop column stack on the task page so it stays paired with the desktop layout
- remove the standalone spacing so the banner now inherits the column gap structure while keeping chat alignment intact

## Testing
- `npm run lint --prefix packages/bytebot-ui` *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d044dcd2d08323b63b58e7b8b17d08