### PR TITLE
Adjust desktop column layout

### DIFF
--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -136,22 +136,22 @@ export default function TaskPage() {
       <Header />
 
       <main className="m-2 flex-1 overflow-hidden px-2 py-4">
-        <div className="mb-4 flex flex-col gap-1 rounded-lg border border-border bg-card px-4 py-3 dark:border-border/60 dark:bg-muted">
-          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Active Model
-          </span>
-          <span className="text-sm font-semibold text-foreground">
-            {modelIdentifier || "Model unavailable"}
-          </span>
-          {modelNameDetails && (
-            <span className="text-xs text-muted-foreground">
-              Identifier: {modelNameDetails}
-            </span>
-          )}
-        </div>
         <div className="grid h-full grid-cols-7 gap-4">
           {/* Main container */}
-          <div className="col-span-4 flex flex-col gap-3">
+          <div className="col-span-4 flex flex-1 flex-col gap-3">
+            <div className="flex flex-col gap-1 rounded-lg border border-border bg-card px-4 py-3 dark:border-border/60 dark:bg-muted">
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Active Model
+              </span>
+              <span className="text-sm font-semibold text-foreground">
+                {modelIdentifier || "Model unavailable"}
+              </span>
+              {modelNameDetails && (
+                <span className="text-xs text-muted-foreground">
+                  Identifier: {modelNameDetails}
+                </span>
+              )}
+            </div>
             <DesktopContainer
               screenshot={taskInactive ? currentScreenshot : null}
               viewOnly={vncViewOnly()}


### PR DESCRIPTION
## Summary
- move the Active Model banner inside the desktop column and keep it directly ahead of the desktop container
- update the desktop column wrapper to include the upstream flex-1 class for proper growth

## Testing
- npm run lint --prefix packages/bytebot-ui *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0481e910083238e6ba5057aee67f4