### PR TITLE
Improve coordinate parsing and clarify grid labels

### DIFF
--- a/packages/bytebot-agent/src/agent/agent.computer-use.spec.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.spec.ts
@@ -1,0 +1,29 @@
+import { parseCoordinateResponse } from './agent.computer-use';
+
+describe('parseCoordinateResponse', () => {
+  it('parses JSON coordinate responses', () => {
+    const result = parseCoordinateResponse('{"x": 10, "y": 20}');
+    expect(result).toEqual({ x: 10, y: 20 });
+  });
+
+  it('prefers global coordinates when provided in parentheses', () => {
+    const result = parseCoordinateResponse(
+      'Coordinates: x=120(860), y=40(660)',
+    );
+    expect(result).toEqual({ x: 860, y: 660 });
+  });
+
+  it('prefers explicit global axis tokens when both local and global are present', () => {
+    const result = parseCoordinateResponse(
+      'local x=120 y=40; global x=860 y=660',
+    );
+    expect(result).toEqual({ x: 860, y: 660 });
+  });
+
+  it('parses coordinate pairs following a global label', () => {
+    const result = parseCoordinateResponse(
+      'Global coordinates are (860, 660) with local (120, 40)',
+    );
+    expect(result).toEqual({ x: 860, y: 660 });
+  });
+});

--- a/packages/bytebotd/src/nut/zoom-screenshot.service.ts
+++ b/packages/bytebotd/src/nut/zoom-screenshot.service.ts
@@ -217,18 +217,18 @@ export class ZoomScreenshotService {
     // X-axis labels (showing both local and global coordinates)
     for (let x = gridSize; x <= width; x += gridSize) {
       const globalCoords = mapping.localToGlobal(x, 0);
-      const label = showGlobalCoordinates ?
-        `${x}(${Math.round(globalCoords.x)})` :
-        `${x}`;
+      const label = showGlobalCoordinates
+        ? `${Math.round(globalCoords.x)} (local ${x})`
+        : `${x}`;
       svgContent += `<text x="${x}" y="${fontSize + 2}" text-anchor="middle">${label}</text>`;
     }
 
     // Y-axis labels (showing both local and global coordinates)
     for (let y = gridSize; y <= height; y += gridSize) {
       const globalCoords = mapping.localToGlobal(0, y);
-      const label = showGlobalCoordinates ?
-        `${y}(${Math.round(globalCoords.y)})` :
-        `${y}`;
+      const label = showGlobalCoordinates
+        ? `${Math.round(globalCoords.y)} (local ${y})`
+        : `${y}`;
       svgContent += `<text x="2" y="${y + fontSize/2}" text-anchor="start">${label}</text>`;
     }
 


### PR DESCRIPTION
## Summary
- refine `parseCoordinateResponse` to reliably pull global coordinates by preferring explicit global markers and last-axis matches
- add regression tests that cover ambiguous coordinate replies to prevent future parsing regressions
- update zoomed grid overlay labels to show global values first, reducing ambiguity between local/global coordinates

## Testing
- `npm run test --prefix packages/bytebot-agent`


------
https://chatgpt.com/codex/tasks/task_e_68d056663f288323811c7c2430315254