### PR TITLE
Add cursor overlays to screenshots

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.computer-use.ts
@@ -78,7 +78,7 @@ export async function handleComputerToolUse(
     logger.debug('Processing focused region screenshot request');
     try {
       const { image, offset } = await screenshotRegion(block.input);
-      const content: Array<{ type: MessageContentType; [key: string]: any }> = [
+      const content: MessageContentBlock[] = [
         {
           type: MessageContentType.Image,
           source: {
@@ -666,6 +666,7 @@ async function screenshot(): Promise<string> {
   try {
     const requestBody = {
       action: 'screenshot',
+      showCursor: true,
     };
 
     const response = await fetch(`${BYTEBOT_DESKTOP_BASE_URL}/computer-use`, {
@@ -709,6 +710,7 @@ async function screenshotRegion(input: {
         gridSize: input.gridSize ?? undefined,
         enhance: input.enhance ?? undefined,
         includeOffset: input.includeOffset ?? undefined,
+        showCursor: true,
       }),
     });
 
@@ -755,6 +757,7 @@ async function screenshotCustomRegion(input: {
         width: input.width,
         height: input.height,
         gridSize: input.gridSize ?? undefined,
+        showCursor: true,
       }),
     });
 

--- a/packages/bytebot-agent/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.ts
@@ -34,6 +34,7 @@ interface ScreenshotOptions {
   gridOverlay?: boolean;
   gridSize?: number;
   highlightRegions?: boolean;
+  showCursor?: boolean;
   progressStep?: number;
   progressMessage?: string;
   progressTaskId?: string;
@@ -51,7 +52,9 @@ interface ScreenshotResponse {
 }
 
 const BYTEBOT_DESKTOP_BASE_URL = process.env.BYTEBOT_DESKTOP_BASE_URL as string;
-const BYTEBOT_LLM_PROXY_URL = process.env.BYTEBOT_LLM_PROXY_URL as string | undefined;
+const BYTEBOT_LLM_PROXY_URL = process.env.BYTEBOT_LLM_PROXY_URL as
+  | string
+  | undefined;
 const SMART_FOCUS_MODEL =
   process.env.BYTEBOT_SMART_FOCUS_MODEL || 'gpt-4o-mini';
 const SMART_FOCUS_ENABLED = process.env.BYTEBOT_SMART_FOCUS !== 'false';
@@ -103,7 +106,9 @@ export async function handleComputerToolUse(
   if (isScreenshotRegionToolUseBlock(block)) {
     logger.debug('Processing focused region screenshot request');
     try {
-      const { image, offset, region, zoomLevel } = await screenshotRegion(block.input);
+      const { image, offset, region, zoomLevel } = await screenshotRegion(
+        block.input,
+      );
       const content: MessageContentBlock[] = [
         {
           type: MessageContentType.Image,
@@ -252,7 +257,9 @@ export async function handleComputerToolUse(
         ],
       };
     } catch (error) {
-      logger.error(`Getting screen info failed: ${error instanceof Error ? error.message : String(error)}`);
+      logger.error(
+        `Getting screen info failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return {
         type: MessageContentType.ToolResult,
         tool_use_id: block.id,
@@ -295,7 +302,10 @@ export async function handleComputerToolUse(
             try {
               coords = await cursorPosition();
             } catch (err) {
-              console.warn('Unable to get cursor position for verification:', err);
+              console.warn(
+                'Unable to get cursor position for verification:',
+                err,
+              );
             }
           }
 
@@ -400,7 +410,9 @@ export async function handleComputerToolUse(
         logger.debug(`Waiting ${delayMs}ms before taking screenshot`);
         await new Promise((resolve) => setTimeout(resolve, delayMs));
 
-        logger.debug('Taking screenshot after tool execution (gridOverlay=true)');
+        logger.debug(
+          'Taking screenshot after tool execution (gridOverlay=true)',
+        );
         screenshotResult = (await screenshot({ gridOverlay: true })).image;
         logger.debug('Screenshot captured successfully');
       }
@@ -444,7 +456,10 @@ export async function handleComputerToolUse(
     return toolResult;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    logger.error(`Error executing ${block.name} tool: ${msg}`, (error as any)?.stack);
+    logger.error(
+      `Error executing ${block.name} tool: ${msg}`,
+      (error as any)?.stack,
+    );
     const friendly =
       block.name === 'computer_click_mouse' && msg.startsWith('Click rejected:')
         ? 'Click rejected: provide coordinates or a short target description so Smart Focus can compute exact coordinates.'
@@ -733,7 +748,7 @@ export function createSmartClickAI(): SmartClickAI | null {
               typeof part === 'string' ? part : 'text' in part ? part.text : '',
             )
             .join('')
-        : message.content ?? '';
+        : (message.content ?? '');
 
       return (content || '').trim();
     },
@@ -773,7 +788,9 @@ export function createSmartClickAI(): SmartClickAI | null {
 
       const message = completion.choices[0]?.message;
       if (!message) {
-        throw new Error('Smart focus coordinate identification returned no result');
+        throw new Error(
+          'Smart focus coordinate identification returned no result',
+        );
       }
 
       const rawContent = Array.isArray(message.content)
@@ -782,7 +799,7 @@ export function createSmartClickAI(): SmartClickAI | null {
               typeof part === 'string' ? part : 'text' in part ? part.text : '',
             )
             .join('')
-        : message.content ?? '';
+        : (message.content ?? '');
 
       const parsed = parseCoordinateResponse(rawContent);
       if (!parsed) {
@@ -1123,6 +1140,7 @@ async function screenshot(
         gridOverlay: options?.gridOverlay ?? undefined,
         gridSize: options?.gridSize ?? undefined,
         highlightRegions: options?.highlightRegions ?? undefined,
+        showCursor: options?.showCursor ?? true,
         progressStep: options?.progressStep ?? undefined,
         progressMessage: options?.progressMessage ?? undefined,
         progressTaskId: options?.progressTaskId ?? undefined,
@@ -1174,6 +1192,7 @@ async function screenshotRegion(input: {
   enhance?: boolean | null;
   includeOffset?: boolean | null;
   addHighlight?: boolean | null;
+  showCursor?: boolean | null;
   progressStep?: number | null;
   progressMessage?: string | null;
   progressTaskId?: string | null;
@@ -1197,6 +1216,7 @@ async function screenshotRegion(input: {
         enhance: input.enhance ?? undefined,
         includeOffset: input.includeOffset ?? undefined,
         addHighlight: input.addHighlight ?? undefined,
+        showCursor: input.showCursor ?? true,
         progressStep: input.progressStep ?? undefined,
         progressMessage: input.progressMessage ?? undefined,
         progressTaskId: input.progressTaskId ?? undefined,
@@ -1235,6 +1255,7 @@ async function screenshotCustomRegion(input: {
   gridSize?: number | null;
   zoomLevel?: number | null;
   markTarget?: { coordinates: Coordinates; label?: string } | null;
+  showCursor?: boolean | null;
   progressStep?: number | null;
   progressMessage?: string | null;
   progressTaskId?: string | null;
@@ -1261,6 +1282,7 @@ async function screenshotCustomRegion(input: {
         gridSize: input.gridSize ?? undefined,
         zoomLevel: input.zoomLevel ?? undefined,
         markTarget: input.markTarget ?? undefined,
+        showCursor: input.showCursor ?? true,
         progressStep: input.progressStep ?? undefined,
         progressMessage: input.progressMessage ?? undefined,
         progressTaskId: input.progressTaskId ?? undefined,

--- a/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
@@ -221,6 +221,10 @@ export class ScreenshotActionDto extends BaseActionDto {
   highlightRegions?: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  showCursor?: boolean;
+
+  @IsOptional()
   @IsNumber()
   progressStep?: number;
 
@@ -277,6 +281,10 @@ export class ScreenshotRegionFocusActionDto extends BaseActionDto {
   addHighlight?: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  showCursor?: boolean;
+
+  @IsOptional()
   @IsNumber()
   progressStep?: number;
 
@@ -313,6 +321,10 @@ export class ScreenshotCustomRegionActionDto extends BaseActionDto {
   @IsNumber()
   @Min(5)
   gridSize?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  showCursor?: boolean;
 }
 
 export class CursorPositionActionDto extends BaseActionDto {

--- a/packages/bytebotd/src/mcp/computer-use.tools.ts
+++ b/packages/bytebotd/src/mcp/computer-use.tools.ts
@@ -120,7 +120,12 @@ export class ComputerUseTools {
           zoomLevel: z.number().optional(),
           targetDescription: z.string().optional(),
           source: z
-            .enum(['manual', 'smart_focus', 'progressive_zoom', 'binary_search'])
+            .enum([
+              'manual',
+              'smart_focus',
+              'progressive_zoom',
+              'binary_search',
+            ])
             .optional(),
         })
         .optional()
@@ -591,6 +596,7 @@ V, W, X, Y, Z
         gridOverlay: z.boolean().optional(),
         gridSize: z.number().optional(),
         highlightRegions: z.boolean().optional(),
+        showCursor: z.boolean().optional(),
         progressStep: z.number().optional(),
         progressMessage: z.string().optional(),
         progressTaskId: z.string().optional(),
@@ -607,6 +613,7 @@ V, W, X, Y, Z
     gridOverlay,
     gridSize,
     highlightRegions,
+    showCursor,
     progressStep,
     progressMessage,
     progressTaskId,
@@ -615,6 +622,7 @@ V, W, X, Y, Z
     gridOverlay?: boolean;
     gridSize?: number;
     highlightRegions?: boolean;
+    showCursor?: boolean;
     progressStep?: number;
     progressMessage?: string;
     progressTaskId?: string;
@@ -626,6 +634,7 @@ V, W, X, Y, Z
         gridOverlay,
         gridSize,
         highlightRegions,
+        showCursor,
         progressStep,
         progressMessage,
         progressTaskId,
@@ -684,6 +693,7 @@ V, W, X, Y, Z
         .boolean()
         .optional()
         .describe('Highlight this region in the output.'),
+      showCursor: z.boolean().optional(),
       progressStep: z.number().optional(),
       progressMessage: z.string().optional(),
       progressTaskId: z.string().optional(),
@@ -695,6 +705,7 @@ V, W, X, Y, Z
     enhance,
     includeOffset,
     addHighlight,
+    showCursor,
     progressStep,
     progressMessage,
     progressTaskId,
@@ -713,6 +724,7 @@ V, W, X, Y, Z
     enhance?: boolean;
     includeOffset?: boolean;
     addHighlight?: boolean;
+    showCursor?: boolean;
     progressStep?: number;
     progressMessage?: string;
     progressTaskId?: string;
@@ -725,6 +737,7 @@ V, W, X, Y, Z
         enhance,
         includeOffset,
         addHighlight,
+        showCursor,
         progressStep,
         progressMessage,
         progressTaskId,
@@ -768,6 +781,7 @@ V, W, X, Y, Z
         .number()
         .optional()
         .describe('Optional grid spacing in pixels for the custom capture.'),
+      showCursor: z.boolean().optional(),
     }),
   })
   async screenshotCustomRegion({
@@ -776,12 +790,14 @@ V, W, X, Y, Z
     width,
     height,
     gridSize,
+    showCursor,
   }: {
     x: number;
     y: number;
     width: number;
     height: number;
     gridSize?: number;
+    showCursor?: boolean;
   }) {
     try {
       const shot = (await this.computerUse.action({
@@ -791,6 +807,7 @@ V, W, X, Y, Z
         width,
         height,
         gridSize,
+        showCursor,
       })) as { image: string };
 
       return {

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -102,6 +102,7 @@ export type ScreenshotAction = {
   gridOverlay?: boolean;
   gridSize?: number;
   highlightRegions?: boolean;
+  showCursor?: boolean;
   progressStep?: number;
   progressMessage?: string;
   progressTaskId?: string;
@@ -127,6 +128,7 @@ export type ScreenshotRegionAction = {
   enhance?: boolean;
   includeOffset?: boolean;
   addHighlight?: boolean;
+  showCursor?: boolean;
   zoomLevel?: number;
   progressStep?: number;
   progressMessage?: string;
@@ -142,6 +144,7 @@ export type ScreenshotCustomRegionAction = {
   height: number;
   gridSize?: number;
   zoomLevel?: number;
+  showCursor?: boolean;
   // Optional: draw a target marker within the returned image.
   // Coordinates are in GLOBAL screen space; daemon maps to local image coords.
   markTarget?: {

--- a/packages/shared/src/types/messageContent.types.ts
+++ b/packages/shared/src/types/messageContent.types.ts
@@ -1,4 +1,9 @@
-import { Button, Coordinates, Press, ClickContext } from "./computerAction.types";
+import {
+  Button,
+  Coordinates,
+  Press,
+  ClickContext,
+} from "./computerAction.types";
 
 // Content block types
 export enum MessageContentType {
@@ -162,6 +167,7 @@ export type ScreenshotToolUseBlock = ToolUseContentBlock & {
     gridOverlay?: boolean;
     gridSize?: number;
     highlightRegions?: boolean;
+    showCursor?: boolean;
     progressStep?: number;
     progressMessage?: string;
     progressTaskId?: string;
@@ -189,6 +195,7 @@ export type ScreenshotRegionToolUseBlock = ToolUseContentBlock & {
     enhance?: boolean;
     includeOffset?: boolean;
     addHighlight?: boolean;
+    showCursor?: boolean;
     progressStep?: number;
     progressMessage?: string;
     progressTaskId?: string;
@@ -203,6 +210,7 @@ export type ScreenshotCustomRegionToolUseBlock = ToolUseContentBlock & {
     width: number;
     height: number;
     gridSize?: number;
+    showCursor?: boolean;
   };
 };
 

--- a/packages/shared/src/utils/computerAction.utils.ts
+++ b/packages/shared/src/utils/computerAction.utils.ts
@@ -29,7 +29,7 @@ import {
  * Type guard factory for computer actions
  */
 function createActionTypeGuard<T extends ComputerAction>(
-  actionType: T["action"]
+  actionType: T["action"],
 ): (obj: unknown) => obj is T {
   return (obj: unknown): obj is T => {
     if (!obj || typeof obj !== "object") {
@@ -67,7 +67,7 @@ export const isScreenshotRegionAction =
   createActionTypeGuard<ScreenshotRegionAction>("screenshot_region");
 export const isScreenshotCustomRegionAction =
   createActionTypeGuard<ScreenshotCustomRegionAction>(
-    "screenshot_custom_region"
+    "screenshot_custom_region",
   );
 export const isCursorPositionAction =
   createActionTypeGuard<CursorPositionAction>("cursor_position");
@@ -82,7 +82,7 @@ export const isApplicationAction =
 function createToolUseBlock(
   toolName: string,
   toolUseId: string,
-  input: Record<string, any>
+  input: Record<string, any>,
 ): ComputerToolUseContentBlock {
   return {
     type: MessageContentType.ToolUse,
@@ -97,7 +97,7 @@ function createToolUseBlock(
  */
 function conditionallyAdd<T extends Record<string, any>>(
   obj: T,
-  conditions: Array<[boolean | undefined, string, any]>
+  conditions: Array<[boolean | undefined, string, any]>,
 ): T {
   const result: Record<string, any> = { ...obj };
   conditions.forEach(([condition, key, value]) => {
@@ -113,7 +113,7 @@ function conditionallyAdd<T extends Record<string, any>>(
  */
 export function convertMoveMouseActionToToolUseBlock(
   action: MoveMouseAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_move_mouse", toolUseId, {
     coordinates: action.coordinates,
@@ -122,35 +122,44 @@ export function convertMoveMouseActionToToolUseBlock(
 
 export function convertTraceMouseActionToToolUseBlock(
   action: TraceMouseAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_trace_mouse",
     toolUseId,
     conditionallyAdd({ path: action.path }, [
       [action.holdKeys !== undefined, "holdKeys", action.holdKeys],
-    ])
+    ]),
   );
 }
 
 export function convertClickMouseActionToToolUseBlock(
   action: ClickMouseAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   const context = action.context
-    ? conditionallyAdd(
-        {},
+    ? conditionallyAdd({}, [
         [
-          [typeof action.context.region !== "undefined", "region", action.context.region],
-          [typeof action.context.zoomLevel === "number", "zoomLevel", action.context.zoomLevel],
-          [
-            typeof action.context.targetDescription === "string",
-            "targetDescription",
-            action.context.targetDescription,
-          ],
-          [typeof action.context.source === "string", "source", action.context.source],
-        ]
-      )
+          typeof action.context.region !== "undefined",
+          "region",
+          action.context.region,
+        ],
+        [
+          typeof action.context.zoomLevel === "number",
+          "zoomLevel",
+          action.context.zoomLevel,
+        ],
+        [
+          typeof action.context.targetDescription === "string",
+          "targetDescription",
+          action.context.targetDescription,
+        ],
+        [
+          typeof action.context.source === "string",
+          "source",
+          action.context.source,
+        ],
+      ])
     : undefined;
 
   return createToolUseBlock(
@@ -166,14 +175,14 @@ export function convertClickMouseActionToToolUseBlock(
         [action.holdKeys !== undefined, "holdKeys", action.holdKeys],
         [action.description !== undefined, "description", action.description],
         [typeof context !== "undefined", "context", context],
-      ]
-    )
+      ],
+    ),
   );
 }
 
 export function convertPressMouseActionToToolUseBlock(
   action: PressMouseAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_press_mouse",
@@ -183,14 +192,14 @@ export function convertPressMouseActionToToolUseBlock(
         button: action.button,
         press: action.press,
       },
-      [[action.coordinates !== undefined, "coordinates", action.coordinates]]
-    )
+      [[action.coordinates !== undefined, "coordinates", action.coordinates]],
+    ),
   );
 }
 
 export function convertDragMouseActionToToolUseBlock(
   action: DragMouseAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_drag_mouse",
@@ -200,14 +209,14 @@ export function convertDragMouseActionToToolUseBlock(
         path: action.path,
         button: action.button,
       },
-      [[action.holdKeys !== undefined, "holdKeys", action.holdKeys]]
-    )
+      [[action.holdKeys !== undefined, "holdKeys", action.holdKeys]],
+    ),
   );
 }
 
 export function convertScrollActionToToolUseBlock(
   action: ScrollAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_scroll",
@@ -220,27 +229,27 @@ export function convertScrollActionToToolUseBlock(
       [
         [action.coordinates !== undefined, "coordinates", action.coordinates],
         [action.holdKeys !== undefined, "holdKeys", action.holdKeys],
-      ]
-    )
+      ],
+    ),
   );
 }
 
 export function convertTypeKeysActionToToolUseBlock(
   action: TypeKeysAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_type_keys",
     toolUseId,
     conditionallyAdd({ keys: action.keys }, [
       [typeof action.delay === "number", "delay", action.delay],
-    ])
+    ]),
   );
 }
 
 export function convertPressKeysActionToToolUseBlock(
   action: PressKeysAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_press_keys", toolUseId, {
     keys: action.keys,
@@ -250,7 +259,7 @@ export function convertPressKeysActionToToolUseBlock(
 
 export function convertTypeTextActionToToolUseBlock(
   action: TypeTextAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_type_text",
@@ -258,13 +267,13 @@ export function convertTypeTextActionToToolUseBlock(
     conditionallyAdd({ text: action.text }, [
       [typeof action.delay === "number", "delay", action.delay],
       [typeof action.sensitive === "boolean", "isSensitive", action.sensitive],
-    ])
+    ]),
   );
 }
 
 export function convertPasteTextActionToToolUseBlock(
   action: PasteTextAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_paste_text", toolUseId, {
     text: action.text,
@@ -273,7 +282,7 @@ export function convertPasteTextActionToToolUseBlock(
 
 export function convertWaitActionToToolUseBlock(
   action: WaitAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_wait", toolUseId, {
     duration: action.duration,
@@ -282,45 +291,51 @@ export function convertWaitActionToToolUseBlock(
 
 export function convertScreenshotActionToToolUseBlock(
   action: ScreenshotAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_screenshot",
     toolUseId,
-    conditionallyAdd(
-      {},
+    conditionallyAdd({}, [
       [
-        [typeof action.gridOverlay === "boolean", "gridOverlay", action.gridOverlay],
-        [typeof action.gridSize === "number", "gridSize", action.gridSize],
-        [
-          typeof action.highlightRegions === "boolean",
-          "highlightRegions",
-          action.highlightRegions,
-        ],
-        [typeof action.progressStep === "number", "progressStep", action.progressStep],
-        [
-          typeof action.progressMessage === "string",
-          "progressMessage",
-          action.progressMessage,
-        ],
-        [
-          typeof action.progressTaskId === "string",
-          "progressTaskId",
-          action.progressTaskId,
-        ],
-        [
-          typeof action.markTarget !== "undefined",
-          "markTarget",
-          action.markTarget,
-        ],
-      ]
-    )
+        typeof action.gridOverlay === "boolean",
+        "gridOverlay",
+        action.gridOverlay,
+      ],
+      [typeof action.gridSize === "number", "gridSize", action.gridSize],
+      [
+        typeof action.highlightRegions === "boolean",
+        "highlightRegions",
+        action.highlightRegions,
+      ],
+      [typeof action.showCursor === "boolean", "showCursor", action.showCursor],
+      [
+        typeof action.progressStep === "number",
+        "progressStep",
+        action.progressStep,
+      ],
+      [
+        typeof action.progressMessage === "string",
+        "progressMessage",
+        action.progressMessage,
+      ],
+      [
+        typeof action.progressTaskId === "string",
+        "progressTaskId",
+        action.progressTaskId,
+      ],
+      [
+        typeof action.markTarget !== "undefined",
+        "markTarget",
+        action.markTarget,
+      ],
+    ]),
   );
 }
 
 export function convertScreenshotRegionActionToToolUseBlock(
   action: ScreenshotRegionAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_screenshot_region",
@@ -342,8 +357,17 @@ export function convertScreenshotRegionActionToToolUseBlock(
           "addHighlight",
           action.addHighlight,
         ],
+        [
+          typeof action.showCursor === "boolean",
+          "showCursor",
+          action.showCursor,
+        ],
         [typeof action.zoomLevel === "number", "zoomLevel", action.zoomLevel],
-        [typeof action.progressStep === "number", "progressStep", action.progressStep],
+        [
+          typeof action.progressStep === "number",
+          "progressStep",
+          action.progressStep,
+        ],
         [
           typeof action.progressMessage === "string",
           "progressMessage",
@@ -355,14 +379,14 @@ export function convertScreenshotRegionActionToToolUseBlock(
           action.progressTaskId,
         ],
         [typeof action.source === "string", "source", action.source],
-      ]
-    )
+      ],
+    ),
   );
 }
 
 export function convertScreenshotCustomRegionActionToToolUseBlock(
   action: ScreenshotCustomRegionAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock(
     "computer_screenshot_custom_region",
@@ -377,29 +401,34 @@ export function convertScreenshotCustomRegionActionToToolUseBlock(
       [
         [typeof action.gridSize === "number", "gridSize", action.gridSize],
         [typeof action.zoomLevel === "number", "zoomLevel", action.zoomLevel],
+        [
+          typeof action.showCursor === "boolean",
+          "showCursor",
+          action.showCursor,
+        ],
         [typeof action.source === "string", "source", action.source],
-      ]
-    )
+      ],
+    ),
   );
 }
 
 export function convertCursorPositionActionToToolUseBlock(
   action: CursorPositionAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_cursor_position", toolUseId, {});
 }
 
 export function convertScreenInfoActionToToolUseBlock(
   action: ScreenInfoAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_screen_info", toolUseId, {});
 }
 
 export function convertApplicationActionToToolUseBlock(
   action: ApplicationAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_application", toolUseId, {
     application: action.application,
@@ -408,7 +437,7 @@ export function convertApplicationActionToToolUseBlock(
 
 export function convertWriteFileActionToToolUseBlock(
   action: WriteFileAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_write_file", toolUseId, {
     path: action.path,
@@ -418,7 +447,7 @@ export function convertWriteFileActionToToolUseBlock(
 
 export function convertReadFileActionToToolUseBlock(
   action: ReadFileAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_read_file", toolUseId, {
     path: action.path,
@@ -430,7 +459,7 @@ export function convertReadFileActionToToolUseBlock(
  */
 export function convertComputerActionToToolUseBlock(
   action: ComputerAction,
-  toolUseId: string
+  toolUseId: string,
 ): ComputerToolUseContentBlock {
   switch (action.action) {
     case "move_mouse":
@@ -462,12 +491,15 @@ export function convertComputerActionToToolUseBlock(
     case "screenshot_custom_region":
       return convertScreenshotCustomRegionActionToToolUseBlock(
         action,
-        toolUseId
+        toolUseId,
       );
     case "cursor_position":
       return convertCursorPositionActionToToolUseBlock(action, toolUseId);
     case "screen_info":
-      return convertScreenInfoActionToToolUseBlock(action as ScreenInfoAction, toolUseId);
+      return convertScreenInfoActionToToolUseBlock(
+        action as ScreenInfoAction,
+        toolUseId,
+      );
     case "application":
       return convertApplicationActionToToolUseBlock(action, toolUseId);
     case "write_file":
@@ -477,7 +509,7 @@ export function convertComputerActionToToolUseBlock(
     default:
       const exhaustiveCheck: never = action;
       throw new Error(
-        `Unknown action type: ${(exhaustiveCheck as any).action}`
+        `Unknown action type: ${(exhaustiveCheck as any).action}`,
       );
   }
 }


### PR DESCRIPTION
## Summary
- add an optional `showCursor` flag to shared screenshot action/message types and daemon DTO validation so clients can request pointer annotation
- extend the daemon grid overlay service with a reusable cursor helper and apply cursor rendering in full, region, and custom screenshot flows
- propagate the new flag through the desktop agents and Smart Click helper so monitoring captures request cursor overlays by default

## Testing
- npm run format --prefix packages/shared
- cd packages/bytebotd && npx prettier --write "src/**/*.ts"
- cd packages/bytebot-agent && npx prettier --write "src/**/*.ts"
- cd packages/bytebot-agent-cc && npx prettier --write "src/**/*.ts"
- npm run build --prefix packages/shared
- npm run build --prefix packages/bytebotd
- npm run build --prefix packages/bytebot-agent
- npm run build --prefix packages/bytebot-agent-cc

------
https://chatgpt.com/codex/tasks/task_e_68d05e860a508323b9fc0aa2dbbc2c65