### PR TITLE
Add session timeline summaries to telemetry endpoints

### DIFF
--- a/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
@@ -1,5 +1,12 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { TelemetryController } from './telemetry.controller';
-import { TelemetryService } from './telemetry.service';
+import {
+  SessionSummaryInfo,
+  TelemetryActionEventSummary,
+  TelemetryService,
+} from './telemetry.service';
 
 describe('TelemetryController', () => {
   it('passes trimmed session from request body to resetAll', async () => {
@@ -13,5 +20,79 @@ describe('TelemetryController', () => {
     await controller.reset(undefined, '  session-from-body  ');
 
     expect(resetAll).toHaveBeenCalledWith('session-from-body');
+  });
+
+  it('includes session timeline data in summary response', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'telemetry-controller-'));
+    try {
+      const logPath = path.join(tempDir, 'click-telemetry.log');
+      const calibrationDir = path.join(tempDir, 'calibration');
+      await fs.mkdir(calibrationDir, { recursive: true });
+      await fs.writeFile(
+        logPath,
+        [
+          {
+            target: { x: 0, y: 0 },
+            actual: { x: 1, y: -1 },
+            delta: { x: 1, y: -1 },
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join('\n') + '\n',
+        'utf8',
+      );
+      await fs.writeFile(path.join(calibrationDir, 'snapshot.png'), 'data', 'utf8');
+
+      const timeline = {
+        sessionStart: '2024-01-01T00:00:00.000Z',
+        sessionEnd: '2024-01-01T00:05:00.000Z',
+        sessionDurationMs: 300000,
+        events: [
+          {
+            type: 'action',
+            timestamp: '2024-01-01T00:01:00.000Z',
+            metadata: { name: 'demo' },
+          },
+        ] as TelemetryActionEventSummary[],
+      };
+
+      const telemetry = {
+        getLogFilePath: jest.fn().mockReturnValue(logPath),
+        getCalibrationDir: jest.fn().mockReturnValue(calibrationDir),
+        getSessionTimeline: jest.fn().mockResolvedValue(timeline),
+      } as unknown as TelemetryService;
+
+      const controller = new TelemetryController(telemetry);
+
+      const summary = await controller.summary();
+      expect(summary.sessionStart).toBe(timeline.sessionStart);
+      expect(summary.sessionEnd).toBe(timeline.sessionEnd);
+      expect(summary.sessionDurationMs).toBe(timeline.sessionDurationMs);
+      expect(summary.events).toEqual(timeline.events);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns session summaries from telemetry service', async () => {
+    const sessions: SessionSummaryInfo[] = [
+      {
+        id: 'default',
+        sessionStart: '2024-01-01T00:00:00.000Z',
+        sessionEnd: '2024-01-01T00:01:00.000Z',
+        sessionDurationMs: 60000,
+      },
+    ];
+    const telemetry = {
+      listSessions: jest.fn().mockResolvedValue({ current: 'default', sessions }),
+    } as unknown as TelemetryService;
+
+    const controller = new TelemetryController(telemetry);
+
+    await expect(controller.sessions()).resolves.toEqual({
+      current: 'default',
+      sessions,
+    });
   });
 });

--- a/packages/bytebotd/src/telemetry/telemetry.service.spec.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.service.spec.ts
@@ -34,4 +34,89 @@ describe('TelemetryService', () => {
     expect(newSessionLog.trim()).not.toHaveLength(0);
     expect(defaultLog.trim()).toHaveLength(0);
   });
+
+  it('summarises session timeline and action events from telemetry logs', async () => {
+    const service = new TelemetryService();
+    await service.waitUntilReady();
+
+    const logPath = service.getLogFilePath('default');
+    const entries = [
+      { type: 'action', timestamp: '2024-01-01T00:00:00.000Z', name: 'first' },
+      { type: 'untargeted_click', timestamp: '2024-01-01T00:05:00.000Z' },
+      {
+        type: 'action',
+        timestamp: '2024-01-01T00:10:00.000Z',
+        name: 'second',
+        detail: 'done',
+        app: 'should-be-ignored',
+      },
+    ];
+    await fs.writeFile(
+      logPath,
+      entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+      'utf8',
+    );
+
+    const summary = await service.getSessionTimeline('default');
+    expect(summary.sessionStart).toBe('2024-01-01T00:00:00.000Z');
+    expect(summary.sessionEnd).toBe('2024-01-01T00:10:00.000Z');
+    expect(summary.sessionDurationMs).toBe(600000);
+    expect(summary.events).toEqual([
+      {
+        type: 'action',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        metadata: { name: 'first' },
+      },
+      {
+        type: 'action',
+        timestamp: '2024-01-01T00:10:00.000Z',
+        metadata: { name: 'second', detail: 'done' },
+      },
+    ]);
+  });
+
+  it('includes timeline information when listing sessions', async () => {
+    const service = new TelemetryService();
+    await service.waitUntilReady();
+
+    const defaultLog = service.getLogFilePath('default');
+    await fs.writeFile(
+      defaultLog,
+      [
+        { type: 'action', timestamp: '2024-01-01T00:00:00.000Z' },
+        { type: 'action', timestamp: '2024-01-01T00:01:00.000Z' },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join('\n') + '\n',
+      'utf8',
+    );
+
+    await service.startSession('secondary');
+    const secondaryLog = service.getLogFilePath('secondary');
+    await fs.writeFile(
+      secondaryLog,
+      JSON.stringify({
+        type: 'action',
+        timestamp: '2024-01-01T01:00:00.000Z',
+      }) + '\n',
+      'utf8',
+    );
+
+    const { current, sessions } = await service.listSessions();
+    expect(current).toBe('secondary');
+    const byId = Object.fromEntries(sessions.map((session) => [session.id, session]));
+
+    expect(byId.default).toEqual({
+      id: 'default',
+      sessionStart: '2024-01-01T00:00:00.000Z',
+      sessionEnd: '2024-01-01T00:01:00.000Z',
+      sessionDurationMs: 60000,
+    });
+    expect(byId.secondary).toEqual({
+      id: 'secondary',
+      sessionStart: '2024-01-01T01:00:00.000Z',
+      sessionEnd: '2024-01-01T01:00:00.000Z',
+      sessionDurationMs: 0,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add telemetry service helpers to derive session start/end times, duration, and recent action events from logs
- include session timeline metadata and recent events in telemetry summary and sessions API responses
- extend telemetry service and controller tests to cover the new timeline calculations and response payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d071628f308323b366949f4abcaa4f