### PR TITLE
Enhance telemetry status UI for richer sessions

### DIFF
--- a/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.helpers.ts
+++ b/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.helpers.ts
@@ -1,0 +1,175 @@
+import { formatDistanceStrict } from "date-fns";
+
+import { TelemetrySummary } from "@/types";
+
+export type NormalizedTelemetrySession = {
+  id: string;
+  label: string;
+  startedAt: string | null;
+  endedAt: string | null;
+  lastEventAt: string | null;
+  eventCount?: number;
+};
+
+export type NormalizedTelemetryEvent = {
+  type: string;
+  timestamp: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export function normalizeTelemetrySession(
+  raw: unknown,
+): NormalizedTelemetrySession | null {
+  if (!raw) {
+    return null;
+  }
+
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return {
+      id: trimmed,
+      label: trimmed,
+      startedAt: null,
+      endedAt: null,
+      lastEventAt: null,
+    };
+  }
+
+  if (typeof raw !== "object") {
+    return null;
+  }
+
+  const candidate = raw as Record<string, unknown>;
+  const idSource = candidate.id ?? candidate.sessionId;
+  const id =
+    typeof idSource === "string" && idSource.trim().length > 0
+      ? idSource.trim()
+      : null;
+  if (!id) {
+    return null;
+  }
+
+  const label =
+    typeof candidate.label === "string" && candidate.label.trim().length > 0
+      ? candidate.label
+      : id;
+  const startedAt =
+    typeof candidate.startedAt === "string" && candidate.startedAt.length > 0
+      ? candidate.startedAt
+      : null;
+  const endedAt =
+    typeof candidate.endedAt === "string" && candidate.endedAt.length > 0
+      ? candidate.endedAt
+      : null;
+  const lastEventAt =
+    typeof candidate.lastEventAt === "string" &&
+    candidate.lastEventAt.length > 0
+      ? candidate.lastEventAt
+      : null;
+  const eventCount =
+    typeof candidate.eventCount === "number" &&
+    Number.isFinite(candidate.eventCount)
+      ? candidate.eventCount
+      : undefined;
+
+  return {
+    id,
+    label,
+    startedAt,
+    endedAt,
+    lastEventAt,
+    eventCount,
+  };
+}
+
+export function normalizeTelemetryEvents(
+  raw: unknown,
+): NormalizedTelemetryEvent[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+
+      const candidate = entry as Record<string, unknown>;
+      const type =
+        typeof candidate.type === "string" && candidate.type.length > 0
+          ? candidate.type
+          : "event";
+      const timestamp =
+        typeof candidate.timestamp === "string" &&
+        candidate.timestamp.length > 0
+          ? candidate.timestamp
+          : null;
+      const metadata = { ...candidate };
+      delete metadata.type;
+      delete metadata.timestamp;
+
+      return { type, timestamp, metadata };
+    })
+    .filter((entry): entry is NormalizedTelemetryEvent => entry !== null);
+}
+
+export function coalesceSessionTimestamps(
+  summaryStart: string | null | undefined,
+  summaryEnd: string | null | undefined,
+  session: NormalizedTelemetrySession | null,
+): { start: string | null; end: string | null } {
+  const startCandidate =
+    typeof summaryStart === "string" && summaryStart.length > 0
+      ? summaryStart
+      : session?.startedAt ?? null;
+  const endCandidate =
+    typeof summaryEnd === "string" && summaryEnd.length > 0
+      ? summaryEnd
+      : session?.endedAt ?? session?.lastEventAt ?? null;
+
+  return { start: startCandidate, end: endCandidate };
+}
+
+export function formatSessionDurationFromTiming(
+  summary: Pick<
+    TelemetrySummary,
+    "sessionDurationMs" | "sessionStart" | "sessionEnd"
+  > | null,
+  session: NormalizedTelemetrySession | null,
+  now: Date = new Date(),
+): string | null {
+  const explicitDuration =
+    summary &&
+    typeof summary.sessionDurationMs === "number" &&
+    Number.isFinite(summary.sessionDurationMs) &&
+    summary.sessionDurationMs > 0
+      ? summary.sessionDurationMs
+      : null;
+  if (explicitDuration) {
+    return formatDistanceStrict(0, explicitDuration, { unit: "second" });
+  }
+
+  const { start, end } = coalesceSessionTimestamps(
+    summary?.sessionStart ?? null,
+    summary?.sessionEnd ?? null,
+    session,
+  );
+  const startDate = parseIsoDate(start);
+  const endDate = parseIsoDate(end) ?? (startDate ? now : null);
+  if (startDate && endDate) {
+    return formatDistanceStrict(startDate, endDate, { unit: "second" });
+  }
+  return null;
+}
+
+export function parseIsoDate(value: string | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/packages/bytebot-ui/src/components/telemetry/__tests__/TelemetryStatus.helpers.test.ts
+++ b/packages/bytebot-ui/src/components/telemetry/__tests__/TelemetryStatus.helpers.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  coalesceSessionTimestamps,
+  formatSessionDurationFromTiming,
+  normalizeTelemetryEvents,
+  normalizeTelemetrySession,
+  type NormalizedTelemetrySession,
+} from "../TelemetryStatus.helpers";
+
+test("normalizeTelemetrySession normalizes string identifiers", () => {
+  const session = normalizeTelemetrySession("session-123");
+  assert.ok(session);
+  assert.equal(session.id, "session-123");
+  assert.equal(session.label, "session-123");
+  assert.equal(session.startedAt, null);
+});
+
+test("normalizeTelemetrySession extracts structured metadata", () => {
+  const session = normalizeTelemetrySession({
+    id: "alpha",
+    label: "Alpha Session",
+    startedAt: "2024-04-01T10:00:00.000Z",
+    endedAt: "2024-04-01T10:05:00.000Z",
+    lastEventAt: "2024-04-01T10:05:30.000Z",
+    eventCount: 42,
+  });
+
+  assert.ok(session);
+  assert.equal(session?.label, "Alpha Session");
+  assert.equal(session?.lastEventAt, "2024-04-01T10:05:30.000Z");
+  assert.equal(session?.eventCount, 42);
+});
+
+test("coalesceSessionTimestamps falls back to session metadata", () => {
+  const session: NormalizedTelemetrySession = {
+    id: "beta",
+    label: "beta",
+    startedAt: "2024-05-05T12:00:00.000Z",
+    endedAt: null,
+    lastEventAt: "2024-05-05T12:03:30.000Z",
+  };
+
+  const { start, end } = coalesceSessionTimestamps(null, null, session);
+  assert.equal(start, "2024-05-05T12:00:00.000Z");
+  assert.equal(end, "2024-05-05T12:03:30.000Z");
+});
+
+test("formatSessionDurationFromTiming prefers explicit duration", () => {
+  const label = formatSessionDurationFromTiming(
+    { sessionDurationMs: 90_000, sessionStart: null, sessionEnd: null },
+    null,
+    new Date(0),
+  );
+
+  assert.equal(label, "2 minutes");
+});
+
+test("normalizeTelemetryEvents extracts metadata and timestamps", () => {
+  const events = normalizeTelemetryEvents([
+    {
+      type: "hover_probe",
+      timestamp: "2024-06-01T09:30:00.000Z",
+      diff: 12.5,
+      app: "firefox",
+    },
+    { type: "custom" },
+  ]);
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0].type, "hover_probe");
+  assert.equal(events[0].timestamp, "2024-06-01T09:30:00.000Z");
+  assert.deepEqual(events[0].metadata, {
+    diff: 12.5,
+    app: "firefox",
+  });
+  assert.equal(events[1].type, "custom");
+  assert.equal(events[1].timestamp, null);
+});

--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -103,13 +103,33 @@ export interface TelemetrySummary {
   postClickDiff?: { count: number; avgDiff: number | null };
   smartClicks?: number; // Successful smart click completions
   progressiveZooms?: number;
+  sessionStart?: string | null;
+  sessionEnd?: string | null;
+  sessionDurationMs?: number | null;
+  events?: TelemetryEvent[];
 }
 
 export interface TelemetryApps {
   apps: Array<{ name: string; count: number }>;
 }
 
+export interface TelemetryEvent {
+  type: string;
+  timestamp: string;
+  app?: string | null;
+  [key: string]: unknown;
+}
+
+export interface TelemetrySessionInfo {
+  id: string;
+  label?: string | null;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  lastEventAt?: string | null;
+  eventCount?: number;
+}
+
 export interface TelemetrySessions {
-  current: string | null;
-  sessions: string[];
+  current: TelemetrySessionInfo | null;
+  sessions: TelemetrySessionInfo[];
 }


### PR DESCRIPTION
## Summary
- expand telemetry summary and session types with timing metadata and event payloads
- update the TelemetryStatus drawer to support selecting sessions, show timing info, and render a scrollable event feed
- add reusable helpers plus unit tests for telemetry normalization behaviour

## Testing
- `npm run test --prefix packages/bytebot-ui` *(fails: local environment cannot install dependencies; npm registry returns 403 when fetching @radix-ui packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d07166168483239942089a4c610944