### PR TITLE
Add screenshot reminders to computer-use agents

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.computer-use.ts
@@ -29,6 +29,9 @@ import { Logger } from '@nestjs/common';
 
 const BYTEBOT_DESKTOP_BASE_URL = process.env.BYTEBOT_DESKTOP_BASE_URL as string;
 
+export const SCREENSHOT_REMINDER_TEXT =
+  'Screenshot captured—produce an exhaustive observation before planning or acting.';
+
 export async function handleComputerToolUse(
   block: ComputerToolUseContentBlock,
   logger: Logger,
@@ -55,6 +58,10 @@ export async function handleComputerToolUse(
               media_type: 'image/png',
               type: 'base64',
             },
+          },
+          {
+            type: MessageContentType.Text,
+            text: SCREENSHOT_REMINDER_TEXT,
           },
         ],
       };
@@ -96,6 +103,11 @@ export async function handleComputerToolUse(
         });
       }
 
+      content.push({
+        type: MessageContentType.Text,
+        text: SCREENSHOT_REMINDER_TEXT,
+      });
+
       return {
         type: MessageContentType.ToolResult,
         tool_use_id: block.id,
@@ -135,6 +147,10 @@ export async function handleComputerToolUse(
               media_type: 'image/png',
               type: 'base64',
             },
+          },
+          {
+            type: MessageContentType.Text,
+            text: SCREENSHOT_REMINDER_TEXT,
           },
         ],
       };

--- a/packages/bytebot-agent/src/agent/agent.computer-use.spec.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.spec.ts
@@ -1,4 +1,13 @@
-import { parseCoordinateResponse } from './agent.computer-use';
+import {
+  handleComputerToolUse,
+  parseCoordinateResponse,
+  SCREENSHOT_REMINDER_TEXT,
+} from './agent.computer-use';
+import {
+  ComputerToolUseContentBlock,
+  MessageContentType,
+} from '@bytebot/shared';
+import { Logger } from '@nestjs/common';
 
 describe('parseCoordinateResponse', () => {
   it('parses JSON coordinate responses', () => {
@@ -25,5 +34,122 @@ describe('parseCoordinateResponse', () => {
       'Global coordinates are (860, 660) with local (120, 40)',
     );
     expect(result).toEqual({ x: 860, y: 660 });
+  });
+});
+
+describe('handleComputerToolUse screenshot reminders', () => {
+  const logger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger;
+  let originalFetch: any;
+
+  beforeAll(() => {
+    originalFetch = (globalThis as any).fetch;
+    process.env.BYTEBOT_DESKTOP_BASE_URL =
+      process.env.BYTEBOT_DESKTOP_BASE_URL || 'http://localhost:1234';
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      (globalThis as any).fetch = originalFetch;
+    } else {
+      delete (globalThis as any).fetch;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('appends reminder text for full screenshots', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ image: 'base64-image' }),
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const block = {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'computer_screenshot',
+      input: {},
+    } as ComputerToolUseContentBlock;
+
+    const result = await handleComputerToolUse(block, logger);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: MessageContentType.Text,
+          text: SCREENSHOT_REMINDER_TEXT,
+        }),
+      ]),
+    );
+  });
+
+  it('appends reminder text for focused region screenshots', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        image: 'base64-image',
+        offset: { x: 1, y: 2 },
+        region: { x: 10, y: 20, width: 100, height: 200 },
+        zoomLevel: 2,
+      }),
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const block = {
+      type: 'tool_use',
+      id: 'tool-2',
+      name: 'computer_screenshot_region',
+      input: {
+        region: '100,100,200,200',
+      },
+    } as unknown as ComputerToolUseContentBlock;
+
+    const result = await handleComputerToolUse(block, logger);
+
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: MessageContentType.Text,
+          text: SCREENSHOT_REMINDER_TEXT,
+        }),
+      ]),
+    );
+  });
+
+  it('appends reminder text for custom region screenshots', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        image: 'base64-image',
+        region: { x: 5, y: 5, width: 50, height: 50 },
+      }),
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const block = {
+      type: 'tool_use',
+      id: 'tool-3',
+      name: 'computer_screenshot_custom_region',
+      input: {
+        x: 5,
+        y: 5,
+        width: 50,
+        height: 50,
+      },
+    } as unknown as ComputerToolUseContentBlock;
+
+    const result = await handleComputerToolUse(block, logger);
+
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: MessageContentType.Text,
+          text: SCREENSHOT_REMINDER_TEXT,
+        }),
+      ]),
+    );
   });
 });

--- a/packages/bytebot-agent/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.ts
@@ -59,6 +59,9 @@ const SMART_FOCUS_MODEL =
   process.env.BYTEBOT_SMART_FOCUS_MODEL || 'gpt-4o-mini';
 const SMART_FOCUS_ENABLED = process.env.BYTEBOT_SMART_FOCUS !== 'false';
 
+export const SCREENSHOT_REMINDER_TEXT =
+  'Screenshot captured—produce an exhaustive observation before planning or acting.';
+
 export async function handleComputerToolUse(
   block: ComputerToolUseContentBlock,
   logger: Logger,
@@ -84,6 +87,10 @@ export async function handleComputerToolUse(
               media_type: 'image/png',
               type: 'base64',
             },
+          },
+          {
+            type: MessageContentType.Text,
+            text: SCREENSHOT_REMINDER_TEXT,
           },
         ],
       };
@@ -128,6 +135,10 @@ export async function handleComputerToolUse(
       content.push({
         type: MessageContentType.Text,
         text: `Focused region metadata: ${JSON.stringify(meta)}. Note: grid labels in the image are global screen coordinates. Use them (not local pixels) when computing click positions.`,
+      });
+      content.push({
+        type: MessageContentType.Text,
+        text: SCREENSHOT_REMINDER_TEXT,
       });
 
       return {
@@ -182,6 +193,10 @@ export async function handleComputerToolUse(
           {
             type: MessageContentType.Text,
             text: `Custom region metadata: ${JSON.stringify(meta)}. Grid labels are global; compute clicks in global coordinates.`,
+          },
+          {
+            type: MessageContentType.Text,
+            text: SCREENSHOT_REMINDER_TEXT,
           },
         ],
       };


### PR DESCRIPTION
## Summary
- append a consistent reminder text to all screenshot tool responses in the agent and agent-cc implementations
- export the reminder constant for reuse and update unit tests to exercise screenshot flows with stubbed fetch responses

## Testing
- npm run build --prefix packages/shared
- npm test --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68d0bbcf52208323892b22782018b2e0