### PR TITLE
Enforce screenshot observation gate

### DIFF
--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -5,6 +5,9 @@ export const DEFAULT_DISPLAY_SIZE = {
   height: 0,
 };
 
+export const SCREENSHOT_OBSERVATION_GUARD_MESSAGE =
+  'Observation required: review the latest screenshot and provide an exhaustive observation before issuing additional computer_* tools.';
+
 export const SUMMARIZATION_SYSTEM_PROMPT = `You are a helpful assistant that summarizes conversations for long-running tasks.
 Your job is to create concise summaries that preserve all important information, tool usage, and key decisions.
 Focus on:


### PR DESCRIPTION
## Summary
- add a shared guard message for screenshot follow-ups and track pending observation state in the agent processor
- enforce the observation gate before executing additional computer_* tool calls and reset it once a non-empty text block appears
- expand processor specs to cover compliant and rejected sequences around the screenshot observation requirement

## Testing
- npm run build --prefix packages/shared
- npm --prefix packages/bytebot-agent test


------
https://chatgpt.com/codex/tasks/task_e_68d0b9c73b988323b2f80f99eaf62853