### PR TITLE
Update README media preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The forkâ€™s Smart Focus workflow narrows attention in three deliberate passesâ€
 
 https://github.com/user-attachments/assets/f271282a-27a3-43f3-9b99-b34007fdd169
 
-https://github.com/user-attachments/assets/72a43cf2-bd87-44c5-a582-e7cbe176f37f
+![Desktop accuracy overlay](docs/images/hawkeye-desktop.svg)
 
 ## What is a Desktop Agent?
 

--- a/docs/images/hawkeye-desktop.svg
+++ b/docs/images/hawkeye-desktop.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Hawkeye desktop accuracy overlay</title>
+  <desc id="desc">Stylized desktop screenshot showing Bytebot Hawkeye accuracy overlay with coordinate grid and focus window.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b2b4b" />
+      <stop offset="1" stop-color="#213a63" />
+    </linearGradient>
+    <style>
+      text { font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif; fill: #e2e8f0; }
+      .caption { font-size: 20px; font-weight: 600; letter-spacing: 0.04em; }
+      .label { font-size: 18px; fill: #38bdf8; font-weight: 500; }
+      .hint { font-size: 16px; fill: #94a3b8; }
+      .grid-line { stroke: rgba(148, 163, 184, 0.35); stroke-width: 1; }
+      .grid-major { stroke: rgba(59, 130, 246, 0.75); stroke-width: 2; }
+      .focus { fill: rgba(14, 165, 233, 0.12); stroke: #38bdf8; stroke-width: 3; stroke-dasharray: 12 10; }
+    </style>
+  </defs>
+  <rect width="960" height="540" fill="url(#bg)" rx="28" />
+  <rect x="40" y="40" width="880" height="460" fill="url(#panel)" opacity="0.85" rx="18" />
+  <g transform="translate(80 80)">
+    <rect width="720" height="360" fill="#0b1220" opacity="0.7" rx="12" />
+    <!-- Major grid lines -->
+    <g>
+      <path class="grid-major" d="M0 60h720" />
+      <path class="grid-major" d="M0 180h720" />
+      <path class="grid-major" d="M0 300h720" />
+      <path class="grid-major" d="M120 0v360" />
+      <path class="grid-major" d="M360 0v360" />
+      <path class="grid-major" d="M600 0v360" />
+    </g>
+    <!-- Minor grid lines -->
+    <g>
+      <path class="grid-line" d="M0 20h720" />
+      <path class="grid-line" d="M0 100h720" />
+      <path class="grid-line" d="M0 140h720" />
+      <path class="grid-line" d="M0 220h720" />
+      <path class="grid-line" d="M0 260h720" />
+      <path class="grid-line" d="M0 340h720" />
+      <path class="grid-line" d="M40 0v360" />
+      <path class="grid-line" d="M80 0v360" />
+      <path class="grid-line" d="M160 0v360" />
+      <path class="grid-line" d="M200 0v360" />
+      <path class="grid-line" d="M240 0v360" />
+      <path class="grid-line" d="M280 0v360" />
+      <path class="grid-line" d="M320 0v360" />
+      <path class="grid-line" d="M400 0v360" />
+      <path class="grid-line" d="M440 0v360" />
+      <path class="grid-line" d="M480 0v360" />
+      <path class="grid-line" d="M520 0v360" />
+      <path class="grid-line" d="M560 0v360" />
+      <path class="grid-line" d="M640 0v360" />
+      <path class="grid-line" d="M680 0v360" />
+    </g>
+    <rect class="focus" x="240" y="110" width="240" height="180" rx="12" />
+    <circle cx="360" cy="200" r="10" fill="#22d3ee" stroke="#0ea5e9" stroke-width="4" />
+    <text class="label" x="360" y="102" text-anchor="middle">Focused zoom</text>
+    <text class="hint" x="360" y="330" text-anchor="middle">Coordinate grid with 100px spacing</text>
+    <text class="hint" x="360" y="352" text-anchor="middle">Smart Focus alignment point</text>
+  </g>
+  <g transform="translate(820 110)">
+    <rect width="80" height="200" rx="12" fill="#0f172a" opacity="0.9" />
+    <text class="caption" x="40" y="42" text-anchor="middle">70%+</text>
+    <text class="hint" x="40" y="70" text-anchor="middle">accuracy</text>
+    <text class="hint" x="40" y="110" text-anchor="middle">after</text>
+    <text class="hint" x="40" y="136" text-anchor="middle">calibration</text>
+    <text class="hint" x="40" y="176" text-anchor="middle">passes</text>
+  </g>
+  <text class="caption" x="80" y="520">Smart Focus targeting locks onto UI elements before issuing the final click.</text>
+</svg>


### PR DESCRIPTION
## Summary
- point the README smart focus preview to a lightweight SVG illustration instead of the removed PNG screenshot
- add the hawkeye desktop accuracy overlay SVG asset under docs/images

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0d0033100832383ea1a230088db06