### PR TITLE
Refresh telemetry sessions after reset

### DIFF
--- a/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
+++ b/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
@@ -136,11 +136,12 @@ export function TelemetryStatus({ className = "" }: Props) {
       if (!res.ok) {
         throw new Error("Failed to reset telemetry");
       }
+      await refreshSessions();
       await refresh();
     } catch {
       setBusy(false);
     }
-  }, [activeSessionId, refresh]);
+  }, [activeSessionId, refresh, refreshSessions]);
 
   const refreshSessions = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- refresh the telemetry sessions list immediately after a reset so the UI tracks the new active session before reloading metrics

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org/@radix-ui/react-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d2d5fbe08323bd39e351a240224b