### PR TITLE
Enforce screenshot observation guard for Claude Code agent

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.processor.spec.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.processor.spec.ts
@@ -1,0 +1,166 @@
+import { AgentProcessor } from './agent.processor';
+import { TaskStatus, Role } from '@prisma/client';
+import {
+  MessageContentType,
+  SCREENSHOT_OBSERVATION_GUARD_MESSAGE,
+} from '@bytebot/shared';
+
+jest.mock('@anthropic-ai/claude-code', () => ({
+  query: jest.fn(),
+}));
+
+import { query } from '@anthropic-ai/claude-code';
+
+type QueryMock = jest.MockedFunction<typeof query>;
+
+const createStream = (messages: any[]): AsyncIterable<any> => ({
+  async *[Symbol.asyncIterator]() {
+    for (const message of messages) {
+      yield message;
+    }
+  },
+});
+
+describe('AgentProcessor (Claude Code)', () => {
+  const createProcessor = () => {
+    const tasksService = {
+      findById: jest.fn().mockResolvedValue({
+        id: 'task-1',
+        status: TaskStatus.RUNNING,
+        description: 'Do the thing',
+      }),
+      update: jest.fn(),
+    };
+
+    const messagesService = {
+      create: jest.fn().mockResolvedValue(null),
+    };
+
+    const inputCaptureService = {
+      start: jest.fn(),
+      stop: jest.fn(),
+    };
+
+    const processor = new AgentProcessor(
+      tasksService as any,
+      messagesService as any,
+      inputCaptureService as any,
+    );
+
+    return { processor, tasksService, messagesService };
+  };
+
+  let queryMock: QueryMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryMock = query as QueryMock;
+  });
+
+  it('clears the screenshot observation gate after a compliant observation reply', async () => {
+    const screenshotMessage = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'mcp__desktop__computer_screenshot',
+            input: {},
+          },
+        ],
+      },
+    };
+
+    const compliantMessage = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'text',
+            text: 'Observed the desktop UI and listed the key regions.',
+          },
+          {
+            type: 'tool_use',
+            id: 'tool-2',
+            name: 'mcp__desktop__computer_click_mouse',
+            input: { x: 100, y: 200, button: 'left' },
+          },
+        ],
+      },
+    };
+
+    queryMock.mockReturnValueOnce(
+      createStream([screenshotMessage, compliantMessage]) as any,
+    );
+
+    const { processor, messagesService } = createProcessor();
+    (processor as any).isProcessing = true;
+
+    await (processor as any).runIteration('task-1');
+
+    expect(messagesService.create).toHaveBeenCalled();
+    expect((processor as any).pendingScreenshotObservation).toBe(false);
+    const assistantPayloads = messagesService.create.mock.calls
+      .filter(([payload]: any[]) => payload.role === Role.ASSISTANT)
+      .map(([payload]: any[]) => payload);
+    expect(assistantPayloads[assistantPayloads.length - 1].content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: MessageContentType.ToolUse,
+          id: 'tool-2',
+        }),
+      ]),
+    );
+  });
+
+  it('emits an error tool result when a computer action follows a screenshot without an observation', async () => {
+    const screenshotMessage = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'mcp__desktop__computer_screenshot',
+            input: {},
+          },
+        ],
+      },
+    };
+
+    const nonObservantMessage = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-2',
+            name: 'mcp__desktop__computer_click_mouse',
+            input: { x: 50, y: 75, button: 'left' },
+          },
+        ],
+      },
+    };
+
+    queryMock.mockReturnValueOnce(
+      createStream([screenshotMessage, nonObservantMessage]) as any,
+    );
+
+    const { processor, messagesService } = createProcessor();
+    (processor as any).isProcessing = true;
+
+    await (processor as any).runIteration('task-1');
+
+    const guardCall = messagesService.create.mock.calls.find(
+      ([payload]: any[]) => payload.role === Role.USER,
+    );
+    expect(guardCall).toBeDefined();
+    const [payload] = guardCall as any[];
+    expect(payload.content[0].is_error).toBe(true);
+    expect(payload.content[0].content[0].text).toBe(
+      SCREENSHOT_OBSERVATION_GUARD_MESSAGE,
+    );
+    expect((processor as any).pendingScreenshotObservation).toBe(true);
+  });
+});

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -1,3 +1,5 @@
+import { SCREENSHOT_OBSERVATION_GUARD_MESSAGE as SHARED_SCREENSHOT_OBSERVATION_GUARD_MESSAGE } from '@bytebot/shared';
+
 // Display size varies by environment. Always rely on on-image grids
 // and corner labels for exact bounds.
 export const DEFAULT_DISPLAY_SIZE = {
@@ -6,7 +8,7 @@ export const DEFAULT_DISPLAY_SIZE = {
 };
 
 export const SCREENSHOT_OBSERVATION_GUARD_MESSAGE =
-  'Observation required: review the latest screenshot and provide an exhaustive observation before issuing additional computer_* tools.';
+  SHARED_SCREENSHOT_OBSERVATION_GUARD_MESSAGE;
 
 export const SUMMARIZATION_SYSTEM_PROMPT = `You are a helpful assistant that summarizes conversations for long-running tasks.
 Your job is to create concise summaries that preserve all important information, tool usage, and key decisions.

--- a/packages/shared/src/constants/agent.constants.ts
+++ b/packages/shared/src/constants/agent.constants.ts
@@ -1,0 +1,2 @@
+export const SCREENSHOT_OBSERVATION_GUARD_MESSAGE =
+  'Observation required: review the latest screenshot and provide an exhaustive observation before issuing additional computer_* tools.';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types/messageContent.types";
 export * from "./utils/messageContent.utils";
 export * from "./utils/computerAction.utils";
 export * from "./types/computerAction.types";
+export * from "./constants/agent.constants";


### PR DESCRIPTION
## Summary
- guard Claude Code assistant replies so computer actions require a fresh textual observation after screenshots and persist rejection tool results
- share the screenshot observation warning constant across packages and add streaming-focused Jest coverage for the Claude Code processor

## Testing
- npm test --prefix packages/bytebot-agent-cc

------
https://chatgpt.com/codex/tasks/task_e_68d0d47a45f48323ab938971c6022ccc