### PR TITLE
Normalize telemetry sessions for UI consumption

### DIFF
--- a/packages/bytebot-agent/src/tasks/tasks.controller.spec.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.spec.ts
@@ -1,0 +1,86 @@
+import { HttpException } from '@nestjs/common';
+
+import { TasksController } from './tasks.controller';
+
+describe('TasksController telemetrySessions', () => {
+  let controller: TasksController;
+  const tasksService = {} as any;
+  const messagesService = {} as any;
+
+  beforeEach(() => {
+    controller = new TasksController(tasksService, messagesService);
+    process.env.BYTEBOT_DESKTOP_BASE_URL = 'http://localhost:4300';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    delete process.env.BYTEBOT_DESKTOP_BASE_URL;
+  });
+
+  it('normalizes daemon session summaries and preserves timeline metadata', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          current: 'session-a',
+          sessions: [
+            {
+              id: 'session-a',
+              sessionStart: '2024-07-01T00:00:00.000Z',
+              sessionEnd: '2024-07-01T00:05:00.000Z',
+              sessionDurationMs: 300_000,
+            },
+            {
+              id: 'session-b',
+              sessionStart: null,
+              sessionEnd: null,
+              sessionDurationMs: null,
+            },
+          ],
+        }),
+      } as unknown as Response);
+
+    const result = await controller.telemetrySessions();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:4300/telemetry/sessions',
+    );
+    expect(result.current?.id).toBe('session-a');
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[0].sessionDurationMs).toBe(300_000);
+    expect(result.sessions[0].startedAt).toBe('2024-07-01T00:00:00.000Z');
+    expect(result.sessions[0].endedAt).toBe('2024-07-01T00:05:00.000Z');
+    expect(result.sessions[1].sessionDurationMs).toBeNull();
+  });
+
+  it('creates a placeholder session when daemon omits metadata for the active id', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        current: 'session-c',
+        sessions: [],
+      }),
+    } as unknown as Response);
+
+    const result = await controller.telemetrySessions();
+
+    expect(result.current?.id).toBe('session-c');
+    expect(result.current?.label).toBe('session-c');
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].sessionDurationMs).toBeNull();
+    expect(result.sessions[0].startedAt).toBeNull();
+  });
+
+  it('propagates fetch failures as HTTP exceptions', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Gateway',
+    } as unknown as Response);
+
+    await expect(controller.telemetrySessions()).rejects.toBeInstanceOf(
+      HttpException,
+    );
+  });
+});

--- a/packages/bytebot-ui/src/components/telemetry/__tests__/TelemetryStatus.helpers.test.ts
+++ b/packages/bytebot-ui/src/components/telemetry/__tests__/TelemetryStatus.helpers.test.ts
@@ -15,6 +15,8 @@ test("normalizeTelemetrySession normalizes string identifiers", () => {
   assert.equal(session.id, "session-123");
   assert.equal(session.label, "session-123");
   assert.equal(session.startedAt, null);
+  assert.equal(session.sessionStart, null);
+  assert.equal(session.sessionDurationMs, null);
 });
 
 test("normalizeTelemetrySession extracts structured metadata", () => {
@@ -25,12 +27,29 @@ test("normalizeTelemetrySession extracts structured metadata", () => {
     endedAt: "2024-04-01T10:05:00.000Z",
     lastEventAt: "2024-04-01T10:05:30.000Z",
     eventCount: 42,
+    sessionDurationMs: 300000,
   });
 
   assert.ok(session);
   assert.equal(session?.label, "Alpha Session");
   assert.equal(session?.lastEventAt, "2024-04-01T10:05:30.000Z");
   assert.equal(session?.eventCount, 42);
+  assert.equal(session?.sessionDurationMs, 300000);
+});
+
+test("normalizeTelemetrySession picks up daemon session summaries", () => {
+  const session = normalizeTelemetrySession({
+    id: "daemon-1",
+    sessionStart: "2024-07-01T00:00:00.000Z",
+    sessionEnd: "2024-07-01T00:10:00.000Z",
+    sessionDurationMs: 600000,
+  });
+
+  assert.ok(session);
+  assert.equal(session?.startedAt, "2024-07-01T00:00:00.000Z");
+  assert.equal(session?.endedAt, "2024-07-01T00:10:00.000Z");
+  assert.equal(session?.sessionStart, "2024-07-01T00:00:00.000Z");
+  assert.equal(session?.sessionDurationMs, 600000);
 });
 
 test("coalesceSessionTimestamps falls back to session metadata", () => {
@@ -40,6 +59,9 @@ test("coalesceSessionTimestamps falls back to session metadata", () => {
     startedAt: "2024-05-05T12:00:00.000Z",
     endedAt: null,
     lastEventAt: "2024-05-05T12:03:30.000Z",
+    sessionStart: "2024-05-05T12:00:00.000Z",
+    sessionEnd: null,
+    sessionDurationMs: null,
   };
 
   const { start, end } = coalesceSessionTimestamps(null, null, session);
@@ -55,6 +77,22 @@ test("formatSessionDurationFromTiming prefers explicit duration", () => {
   );
 
   assert.equal(label, "2 minutes");
+});
+
+test("formatSessionDurationFromTiming falls back to session duration", () => {
+  const session: NormalizedTelemetrySession = {
+    id: "daemon-1",
+    label: "daemon-1",
+    startedAt: null,
+    endedAt: null,
+    lastEventAt: null,
+    sessionStart: null,
+    sessionEnd: null,
+    sessionDurationMs: 45_000,
+  };
+
+  const label = formatSessionDurationFromTiming(null, session, new Date(0));
+  assert.equal(label, "1 minute");
 });
 
 test("normalizeTelemetryEvents extracts metadata and timestamps", () => {

--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -127,6 +127,9 @@ export interface TelemetrySessionInfo {
   endedAt?: string | null;
   lastEventAt?: string | null;
   eventCount?: number;
+  sessionStart?: string | null;
+  sessionEnd?: string | null;
+  sessionDurationMs?: number | null;
 }
 
 export interface TelemetrySessions {


### PR DESCRIPTION
## Summary
- normalize telemetry session responses in the agent controller so the UI receives structured session metadata
- extend the telemetry helper/types on the UI to surface session start, end, and duration fields
- add unit coverage on both sides to confirm the timeline fields are preserved and parsed correctly

## Testing
- npm run build --prefix packages/shared
- npm test --prefix packages/bytebot-agent
- npm test --prefix packages/bytebot-ui *(fails: missing local tsx binary due to package installation restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e8d91d9483238cc5e4a0b6b6200a