### PR TITLE
Expose vision capabilities for LiteLLM-backed models

### DIFF
--- a/docs/deployment/litellm.mdx
+++ b/docs/deployment/litellm.mdx
@@ -136,6 +136,11 @@ graph LR
 
 ## Provider Configurations
 
+### Vision model support
+
+1. **Mark vision-capable backends.** Set `supports_vision: true` under `litellm_params` for any alias that can interpret screenshots or image uploads. The agent surfaces this flag in `/tasks/models`, allowing the UI (and automations such as Smart Focus) to distinguish which models can receive desktop captures.
+2. **Choose the active Smart Focus model.** Point `BYTEBOT_SMART_FOCUS_MODEL` at the LiteLLM alias you want Smart Focus to call. Combined with `BYTEBOT_LLM_PROXY_URL`, this environment variable lets you flip between OpenAI, Anthropic, Gemini, or local multimodal backends without redeploying the agent.
+
 ### Azure OpenAI
 
 ```yaml

--- a/packages/bytebot-agent-cc/src/agent/agent.types.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.types.ts
@@ -25,6 +25,7 @@ export interface BytebotAgentModel {
   name: string;
   title: string;
   contextWindow?: number;
+  supportsVision?: boolean;
 }
 
 export class BytebotAgentInterrupt extends Error {

--- a/packages/bytebot-agent-cc/src/tasks/tasks.controller.ts
+++ b/packages/bytebot-agent-cc/src/tasks/tasks.controller.ts
@@ -58,6 +58,7 @@ export class TasksController {
         name: 'claude-code',
         title: 'Claude Code',
         contextWindow: 200000,
+        supportsVision: true,
       },
     ];
   }

--- a/packages/bytebot-agent/src/agent/agent.types.ts
+++ b/packages/bytebot-agent/src/agent/agent.types.ts
@@ -25,6 +25,7 @@ export interface BytebotAgentModel {
   name: string;
   title: string;
   contextWindow?: number;
+  supportsVision?: boolean;
 }
 
 export class BytebotAgentInterrupt extends Error {

--- a/packages/bytebot-agent/src/anthropic/anthropic.constants.ts
+++ b/packages/bytebot-agent/src/anthropic/anthropic.constants.ts
@@ -6,12 +6,14 @@ export const ANTHROPIC_MODELS: BytebotAgentModel[] = [
     name: 'claude-opus-4-1-20250805',
     title: 'Claude Opus 4.1',
     contextWindow: 200000,
+    supportsVision: true,
   },
   {
     provider: 'anthropic',
     name: 'claude-sonnet-4-20250514',
     title: 'Claude Sonnet 4',
     contextWindow: 200000,
+    supportsVision: true,
   },
 ];
 

--- a/packages/bytebot-agent/src/google/google.constants.ts
+++ b/packages/bytebot-agent/src/google/google.constants.ts
@@ -6,12 +6,14 @@ export const GOOGLE_MODELS: BytebotAgentModel[] = [
     name: 'gemini-2.5-pro',
     title: 'Gemini 2.5 Pro',
     contextWindow: 1000000,
+    supportsVision: true,
   },
   {
     provider: 'google',
     name: 'gemini-2.5-flash',
     title: 'Gemini 2.5 Flash',
     contextWindow: 1000000,
+    supportsVision: true,
   },
 ];
 

--- a/packages/bytebot-agent/src/openai/openai.constants.ts
+++ b/packages/bytebot-agent/src/openai/openai.constants.ts
@@ -6,12 +6,14 @@ export const OPENAI_MODELS: BytebotAgentModel[] = [
     name: 'o3-2025-04-16',
     title: 'o3',
     contextWindow: 200000,
+    supportsVision: false,
   },
   {
     provider: 'openai',
     name: 'gpt-4.1-2025-04-14',
     title: 'GPT-4.1',
     contextWindow: 1047576,
+    supportsVision: true,
   },
 ];
 

--- a/packages/bytebot-agent/src/tasks/tasks.controller.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.ts
@@ -100,12 +100,20 @@ export class TasksController {
 
         // Map proxy response to BytebotAgentModel format
         const models: BytebotAgentModel[] = proxyModels.data.map(
-          (model: any) => ({
-            provider: 'proxy',
-            name: model.litellm_params.model,
-            title: model.model_name,
-            contextWindow: 128000,
-          }),
+          (model: any) => {
+            const supportsVision =
+              model.supports_vision === true ||
+              model.litellm_params?.supports_vision === true ||
+              model.litellm_params?.supports_image_input === true;
+
+            return {
+              provider: 'proxy',
+              name: model.litellm_params.model,
+              title: model.model_name,
+              contextWindow: 128000,
+              supportsVision,
+            } satisfies BytebotAgentModel;
+          },
         );
 
         return models;

--- a/packages/bytebot-llm-proxy/litellm-config.yaml
+++ b/packages/bytebot-llm-proxy/litellm-config.yaml
@@ -3,14 +3,17 @@ model_list:
     litellm_params:
       model: anthropic/claude-opus-4-20250514
       api_key: os.environ/ANTHROPIC_API_KEY
+      supports_vision: true
   - model_name: claude-sonnet-4
     litellm_params:
       model: anthropic/claude-sonnet-4-20250514
       api_key: os.environ/ANTHROPIC_API_KEY
+      supports_vision: true
   - model_name: gpt-4o
     litellm_params:
       model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
+      supports_vision: true
   - model_name: o3-pro
     litellm_params:
       model: openai/o3-pro
@@ -23,10 +26,12 @@ model_list:
     litellm_params:
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
+      supports_vision: true
   - model_name: gpt-4.1
     litellm_params:
       model: openai/gpt-4.1
       api_key: os.environ/OPENAI_API_KEY
+      supports_vision: true
   - model_name: gpt-5-thinking
     litellm_params:
       model: openai/gpt-5
@@ -48,27 +53,33 @@ model_list:
       model: vertex_ai/gemini-1.5-pro
       vertex_project: gen-lang-client-0096858366
       vertex_location: us-central1
+      supports_vision: true
   - model_name: gemini-vertex-flash
     litellm_params:
       model: vertex_ai/gemini-1.5-flash
       vertex_project: gen-lang-client-0096858366
       vertex_location: us-central1
+      supports_vision: true
   - model_name: gemini-1.5-pro
     litellm_params:
       model: gemini/gemini-1.5-pro-latest
       api_key: os.environ/GEMINI_API_KEY
+      supports_vision: true
   - model_name: gemini-1.5-flash
     litellm_params:
       model: gemini/gemini-1.5-flash-latest
       api_key: os.environ/GEMINI_API_KEY
+      supports_vision: true
   - model_name: openrouter-claude-3.5-sonnet
     litellm_params:
       model: openrouter/anthropic/claude-3.5-sonnet
       api_key: os.environ/OPENROUTER_API_KEY
+      supports_vision: true
   - model_name: openrouter-claude-3.7-sonnet
     litellm_params:
       model: openrouter/anthropic/claude-3.7-sonnet
       api_key: os.environ/OPENROUTER_API_KEY
+      supports_vision: true
   - model_name: openrouter-grok-4-fast-free
     litellm_params:
       model: openrouter/x-ai/grok-4-fast:free
@@ -77,18 +88,22 @@ model_list:
     litellm_params:
       model: openrouter/google/gemini-2.5-flash
       api_key: os.environ/OPENROUTER_API_KEY
+      supports_vision: true
   - model_name: openrouter-gemini-2.5-pro
     litellm_params:
       model: openrouter/google/gemini-2.5-pro
       api_key: os.environ/OPENROUTER_API_KEY
+      supports_vision: true
   - model_name: openrouter-/internvl3-78b
     litellm_params:
       model: openrouter/opengvlab/internvl3-78b
       api_key: os.environ/OPENROUTER_API_KEY
+      supports_vision: true
   - model_name: openrouter-gemini-1.5-pro
     litellm_params:
       model: openrouter/google/gemini-1.5-pro-latest
       api_key: os.environ/OPENROUTER_API_KEY
+      supports_vision: true
   # Add local models via LMStudio
   - model_name: local-lmstudio-ui-tars-72b-dpo
     litellm_params:
@@ -108,6 +123,7 @@ model_list:
       api_base: http://192.168.4.250:1234/v1
       api_key: lm-studio
       supports_function_calling: true
+      supports_vision: true
   - model_name: local-lmstudio-ui-tars-7b-dpo
     litellm_params:
       model: openai/ui-tars-7b-dpo

--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -26,6 +26,7 @@ export interface Model {
   provider: string;
   name: string;
   title: string;
+  supportsVision?: boolean;
 }
 
 // Task related enums and types


### PR DESCRIPTION
## Summary
- document how to flag multimodal backends and choose the Smart Focus alias when configuring LiteLLM
- extend the agent, control center, and UI model types with a `supportsVision` flag and expose proxy metadata from `/tasks/models`
- mark known multimodal aliases in `litellm-config.yaml` so the proxy advertises vision support

## Testing
- npm run format --prefix packages/bytebot-agent
- npm run format --prefix packages/bytebot-agent-cc
- npm run lint --prefix packages/bytebot-agent *(fails: existing lint violations throughout the package)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ed2a60148323bde3d2a52ca53f10