### PR TITLE
Refactor agent file storage to shared volume

### DIFF
--- a/docs/file-storage-migration.md
+++ b/docs/file-storage-migration.md
@@ -1,0 +1,102 @@
+# File Storage Migration Guide
+
+This guide explains how to migrate existing task file uploads from the legacy
+`File.data` column (base64-encoded blobs) to the new shared filesystem storage
+introduced by the Bytebot agent. The process is designed to be repeatable,
+scripted, and reversible when necessary.
+
+## Summary of Changes
+
+- Prisma schema now records `storage_path` and `storage_provider` metadata
+  instead of inline base64 payloads.
+- Legacy base64 data has been renamed to `legacy_data` in the database and is
+  ignored by the Prisma client.
+- A reusable `FileStorageService` streams incoming uploads directly to a shared
+  volume (`BYTEBOT_SHARED_STORAGE_PATH`) during task creation.
+- The agent scheduler copies staged files from shared storage into the desktop
+  mount (`BYTEBOT_DESKTOP_MOUNT_PATH`) instead of invoking the daemon's
+  `write_file` HTTP endpoint.
+- A data migration script transforms historical rows and supports rollback.
+
+## Prerequisites
+
+1. Ensure the shared storage directory is mounted and writable by the agent and
+   desktop daemon. Configure via `BYTEBOT_SHARED_STORAGE_PATH` (defaults to
+   `/var/bytebot/uploads`).
+2. Confirm the desktop daemon observes the same directory used by the scheduler
+   (default `/home/user/Desktop` or override with `BYTEBOT_DESKTOP_MOUNT_PATH`).
+3. Back up the `File` table or database before running any migrations.
+
+## Migration Steps
+
+1. **Apply Prisma schema changes**
+
+   ```bash
+   cd packages/bytebot-agent
+   npx prisma migrate deploy
+   ```
+
+   This adds `storage_path`, `storage_provider`, and renames `data` to
+   `legacy_data`.
+
+2. **Dry-run the data migration (optional but recommended)**
+
+   ```bash
+   npx ts-node scripts/migrate-file-storage.ts --dry-run
+   ```
+
+   Review the planned file movements and ensure the storage path is correct.
+
+3. **Execute the migration**
+
+   ```bash
+   npx ts-node scripts/migrate-file-storage.ts
+   ```
+
+   The script streams each legacy base64 payload to disk, updates
+   `storage_path`, and clears `legacy_data`.
+
+4. **Verify results**
+
+   - Confirm files exist on disk under the shared storage directory grouped by
+     task ID.
+   - Inspect the `File` table: `storage_path` should be populated and
+     `legacy_data` should be `NULL`.
+   - Trigger a task run to confirm the agent scheduler stages files onto the
+     desktop mount.
+
+## Rollback Procedure
+
+If you must revert to the previous inline-storage implementation:
+
+1. **Restore base64 payloads**
+
+   ```bash
+   cd packages/bytebot-agent
+   npx ts-node scripts/migrate-file-storage.ts --rollback
+   ```
+
+   This reads each staged file from shared storage, re-encodes it to base64,
+   and places the value back into `legacy_data` while clearing `storage_path`.
+
+2. **Revert application code and schema**
+
+   - Check out the prior Git revision that used the inline storage model.
+   - Run `npx prisma migrate resolve --applied <migration_id>` as needed to mark
+     the latest migration as rolled back, or rebuild the database from backup.
+
+3. **Restart services** to ensure they load the older Prisma client and stop
+   referencing the shared storage paths.
+
+> **Note:** The rollback process does not delete files on disk. Remove them
+> manually only after confirming the database has been restored and no longer
+> references the shared storage paths.
+
+## Operational Tips
+
+- The migration script is idempotent—running it again will skip files that
+  already have `storage_path` set (forward) or missing on disk (rollback).
+- Use the `--dry-run` flag in both directions to audit planned updates without
+  touching the database.
+- Monitor disk capacity on the shared volume during the first migration, as it
+  will mirror the size of existing base64 data.

--- a/packages/bytebot-agent-cc/prisma/migrations/20250901093000_file_storage_metadata/migration.sql
+++ b/packages/bytebot-agent-cc/prisma/migrations/20250901093000_file_storage_metadata/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "File" RENAME COLUMN "data" TO "legacy_data";
+
+ALTER TABLE "File"
+    ADD COLUMN "storage_path" TEXT,
+    ADD COLUMN "storage_provider" TEXT NOT NULL DEFAULT 'filesystem';
+
+UPDATE "File"
+SET "storage_path" = COALESCE("storage_path", '');
+
+ALTER TABLE "File"
+    ALTER COLUMN "storage_path" SET NOT NULL;
+
+ALTER TABLE "File"
+    ALTER COLUMN "storage_provider" DROP DEFAULT;

--- a/packages/bytebot-agent-cc/prisma/schema.prisma
+++ b/packages/bytebot-agent-cc/prisma/schema.prisma
@@ -99,16 +99,18 @@ model Message {
 }
 
 model File {
-  id            String      @id @default(uuid())
-  name          String
-  type          String      // MIME type
-  size          Int         // Size in bytes
-  data          String      // Base64 encoded file data
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
-  
+  id               String   @id @default(uuid())
+  name             String
+  type             String // MIME type
+  size             Int // Size in bytes
+  storagePath      String  @map("storage_path")
+  storageProvider  String  @default("filesystem") @map("storage_provider")
+  legacyData       String? @map("legacy_data") @db.Text @ignore
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
   // Relations
-  task          Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  taskId        String
+  task   Task   @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  taskId String
 }
 

--- a/packages/bytebot-agent-cc/src/agent/agent.scheduler.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.scheduler.ts
@@ -3,7 +3,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { TasksService } from '../tasks/tasks.service';
 import { AgentProcessor } from './agent.processor';
 import { TaskStatus } from '@prisma/client';
-import { writeFile } from './agent.computer-use';
+import { FileStorageService } from '../tasks/file-storage.service';
 
 @Injectable()
 export class AgentScheduler implements OnModuleInit {
@@ -12,6 +12,7 @@ export class AgentScheduler implements OnModuleInit {
   constructor(
     private readonly tasksService: TasksService,
     private readonly agentProcessor: AgentProcessor,
+    private readonly fileStorageService: FileStorageService,
   ) {}
 
   async onModuleInit() {
@@ -42,13 +43,34 @@ export class AgentScheduler implements OnModuleInit {
     if (task) {
       if (task.files.length > 0) {
         this.logger.debug(
-          `Task ID: ${task.id} has files, writing them to the desktop`,
+          `Task ID: ${task.id} has files, staging them from shared storage`,
         );
         for (const file of task.files) {
-          await writeFile({
-            path: `/home/user/Desktop/${file.name}`,
-            content: file.data, // file.data is already base64 encoded in the database
-          });
+          if (!file.storagePath) {
+            this.logger.warn(
+              `Skipping file ${file.name} for task ${task.id} because storagePath is missing`,
+            );
+            continue;
+          }
+
+          if (file.storageProvider !== this.fileStorageService.provider) {
+            this.logger.warn(
+              `Skipping file ${file.name} for task ${task.id} due to unsupported provider ${file.storageProvider}`,
+            );
+            continue;
+          }
+
+          try {
+            const destination = await this.fileStorageService.copyToDesktop(file);
+            this.logger.debug(
+              `Copied file ${file.name} for task ${task.id} to ${destination}`,
+            );
+          } catch (error) {
+            this.logger.error(
+              `Failed to prepare file ${file.name} for task ${task.id}: ${error.message}`,
+              error.stack,
+            );
+          }
         }
       }
 

--- a/packages/bytebot-agent-cc/src/tasks/file-storage.service.ts
+++ b/packages/bytebot-agent-cc/src/tasks/file-storage.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createWriteStream, promises as fsPromises } from 'fs';
+import { join, parse, relative, resolve } from 'path';
+import { once } from 'events';
+import { finished } from 'stream/promises';
+
+const DEFAULT_STORAGE_DIR = resolve('/var', 'bytebot', 'uploads');
+const DEFAULT_DESKTOP_DIR = '/home/user/Desktop';
+
+interface PersistedFileMetadata {
+  absolutePath: string;
+  relativePath: string;
+}
+
+@Injectable()
+export class FileStorageService {
+  private readonly logger = new Logger(FileStorageService.name);
+  private readonly storageRoot: string;
+  readonly provider = 'filesystem';
+
+  constructor(private readonly configService: ConfigService) {
+    const configuredRoot = this.configService.get<string>(
+      'BYTEBOT_SHARED_STORAGE_PATH',
+    );
+    this.storageRoot = configuredRoot
+      ? resolve(configuredRoot)
+      : DEFAULT_STORAGE_DIR;
+    this.logger.log(`Using shared storage root: ${this.storageRoot}`);
+  }
+
+  getStorageRoot(): string {
+    return this.storageRoot;
+  }
+
+  getDesktopMountPath(): string {
+    const configured = this.configService.get<string>(
+      'BYTEBOT_DESKTOP_MOUNT_PATH',
+    );
+    return configured ? resolve(configured) : DEFAULT_DESKTOP_DIR;
+  }
+
+  getAbsolutePath(relativePath: string): string {
+    return resolve(this.storageRoot, relativePath);
+  }
+
+  async persistBase64File(
+    taskId: string,
+    file: { name: string; base64: string },
+  ): Promise<PersistedFileMetadata> {
+    const base64Data = this.extractBase64Payload(file.base64);
+    const sanitizedName = this.sanitizeFileName(file.name);
+    const taskDirectory = join(this.storageRoot, taskId);
+    await fsPromises.mkdir(taskDirectory, { recursive: true });
+    const destinationPath = await this.generateUniquePath(
+      taskDirectory,
+      sanitizedName,
+    );
+
+    await this.writeBase64ToFile(base64Data, destinationPath);
+
+    const relativePath = relative(this.storageRoot, destinationPath);
+
+    return {
+      absolutePath: destinationPath,
+      relativePath,
+    };
+  }
+
+  async copyToDesktop(
+    file: { name: string; storagePath: string },
+  ): Promise<string> {
+    const absoluteSourcePath = this.getAbsolutePath(file.storagePath);
+    const desktopMount = this.getDesktopMountPath();
+    await fsPromises.mkdir(desktopMount, { recursive: true });
+    const destinationPath = await this.generateUniquePath(
+      desktopMount,
+      this.sanitizeFileName(file.name),
+    );
+
+    await fsPromises.copyFile(absoluteSourcePath, destinationPath);
+
+    return destinationPath;
+  }
+
+  private sanitizeFileName(filename: string): string {
+    const trimmed = filename.trim();
+    const basename = trimmed.replace(/\\+/g, '/').split('/').pop() ?? 'file';
+    const { name, ext } = parse(basename);
+    const safeName = name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200) || 'file';
+    const safeExt = ext.replace(/[^a-zA-Z0-9._-]/g, '').slice(0, 25);
+    return `${safeName}${safeExt}`;
+  }
+
+  private extractBase64Payload(base64: string): string {
+    if (base64.includes('base64,')) {
+      return base64.slice(base64.indexOf('base64,') + 'base64,'.length);
+    }
+
+    return base64;
+  }
+
+  private async writeBase64ToFile(data: string, destination: string) {
+    const stream = createWriteStream(destination, { mode: 0o600 });
+
+    try {
+      const chunkSize = 1024 * 512; // 512KB
+      for (let offset = 0; offset < data.length; offset += chunkSize) {
+        const chunk = data.slice(offset, offset + chunkSize);
+        const buffer = Buffer.from(chunk, 'base64');
+        if (!stream.write(buffer)) {
+          await once(stream, 'drain');
+        }
+      }
+      stream.end();
+      await finished(stream);
+    } catch (error) {
+      stream.destroy();
+      await this.safeRemove(destination);
+      throw error;
+    }
+  }
+
+  private async generateUniquePath(
+    directory: string,
+    filename: string,
+  ): Promise<string> {
+    let candidate = join(directory, filename);
+    const { name, ext } = parse(filename);
+    let attempt = 0;
+
+    while (await this.pathExists(candidate)) {
+      attempt += 1;
+      const nextName = `${name}-${attempt}${ext}`;
+      candidate = join(directory, nextName);
+    }
+
+    return candidate;
+  }
+
+  private async pathExists(target: string): Promise<boolean> {
+    try {
+      await fsPromises.access(target);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async safeRemove(target: string) {
+    try {
+      await fsPromises.rm(target, { force: true });
+    } catch (error) {
+      this.logger.warn(`Failed to cleanup temporary file ${target}: ${error}`);
+    }
+  }
+}

--- a/packages/bytebot-agent-cc/src/tasks/tasks.module.ts
+++ b/packages/bytebot-agent-cc/src/tasks/tasks.module.ts
@@ -4,11 +4,12 @@ import { TasksService } from './tasks.service';
 import { TasksGateway } from './tasks.gateway';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MessagesModule } from '../messages/messages.module';
+import { FileStorageService } from './file-storage.service';
 
 @Module({
   imports: [PrismaModule, MessagesModule],
   controllers: [TasksController],
-  providers: [TasksService, TasksGateway],
-  exports: [TasksService, TasksGateway],
+  providers: [TasksService, TasksGateway, FileStorageService],
+  exports: [TasksService, TasksGateway, FileStorageService],
 })
 export class TasksModule {}

--- a/packages/bytebot-agent-cc/src/tasks/tasks.service.ts
+++ b/packages/bytebot-agent-cc/src/tasks/tasks.service.ts
@@ -22,6 +22,7 @@ import { AddTaskMessageDto } from './dto/add-task-message.dto';
 import { TasksGateway } from './tasks.gateway';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { FileStorageService } from './file-storage.service';
 
 @Injectable()
 export class TasksService {
@@ -33,6 +34,7 @@ export class TasksService {
     private readonly tasksGateway: TasksGateway,
     private readonly configService: ConfigService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly fileStorageService: FileStorageService,
   ) {
     this.logger.log('TasksService initialized');
   }
@@ -69,26 +71,28 @@ export class TasksService {
         );
         filesDescription += `\n`;
 
-        const filePromises = createTaskDto.files.map((file) => {
-          // Extract base64 data without the data URL prefix
-          const base64Data = file.base64.includes('base64,')
-            ? file.base64.split('base64,')[1]
-            : file.base64;
+        for (const file of createTaskDto.files) {
+          const persisted = await this.fileStorageService.persistBase64File(
+            task.id,
+            file,
+          );
+          filesDescription += `\nFile ${file.name} uploaded to shared storage.`;
 
-          filesDescription += `\nFile ${file.name} written to desktop.`;
-
-          return prisma.file.create({
+          await prisma.file.create({
             data: {
               name: file.name,
               type: file.type || 'application/octet-stream',
               size: file.size,
-              data: base64Data,
+              storagePath: persisted.relativePath,
+              storageProvider: this.fileStorageService.provider,
               taskId: task.id,
             },
           });
-        });
 
-        await Promise.all(filePromises);
+          this.logger.debug(
+            `Stored file ${file.name} for task ${task.id} at ${persisted.relativePath}`,
+          );
+        }
         this.logger.debug(`Files saved successfully for task ID: ${task.id}`);
       }
 

--- a/packages/bytebot-agent/prisma/migrations/20250901093000_file_storage_metadata/migration.sql
+++ b/packages/bytebot-agent/prisma/migrations/20250901093000_file_storage_metadata/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "File" RENAME COLUMN "data" TO "legacy_data";
+
+ALTER TABLE "File"
+    ADD COLUMN "storage_path" TEXT,
+    ADD COLUMN "storage_provider" TEXT NOT NULL DEFAULT 'filesystem';
+
+UPDATE "File"
+SET "storage_path" = COALESCE("storage_path", '');
+
+ALTER TABLE "File"
+    ALTER COLUMN "storage_path" SET NOT NULL;
+
+ALTER TABLE "File"
+    ALTER COLUMN "storage_provider" DROP DEFAULT;

--- a/packages/bytebot-agent/prisma/schema.prisma
+++ b/packages/bytebot-agent/prisma/schema.prisma
@@ -99,13 +99,15 @@ model Message {
 }
 
 model File {
-  id        String   @id @default(uuid())
-  name      String
-  type      String // MIME type
-  size      Int // Size in bytes
-  data      String // Base64 encoded file data
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id               String   @id @default(uuid())
+  name             String
+  type             String // MIME type
+  size             Int // Size in bytes
+  storagePath      String  @map("storage_path")
+  storageProvider  String  @default("filesystem") @map("storage_provider")
+  legacyData       String? @map("legacy_data") @db.Text @ignore
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
   // Relations
   task   Task   @relation(fields: [taskId], references: [id], onDelete: Cascade)

--- a/packages/bytebot-agent/scripts/migrate-file-storage.ts
+++ b/packages/bytebot-agent/scripts/migrate-file-storage.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env ts-node
+
+import { PrismaClient } from '@prisma/client';
+import { createWriteStream, promises as fsPromises } from 'fs';
+import { once } from 'events';
+import { finished } from 'stream/promises';
+import { join, parse, relative, resolve } from 'path';
+
+type Direction = 'forward' | 'rollback';
+
+interface CliOptions {
+  direction: Direction;
+  dryRun: boolean;
+}
+
+interface FileRow {
+  id: string;
+  name: string;
+  taskId: string;
+  storagePath?: string | null;
+  legacyData?: string | null;
+}
+
+const prisma = new PrismaClient();
+const DEFAULT_STORAGE_ROOT = resolve('/var', 'bytebot', 'uploads');
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const direction = args.includes('--rollback') ? 'rollback' : 'forward';
+  const dryRun = args.includes('--dry-run');
+  return { direction, dryRun };
+}
+
+function resolveStorageRoot(): string {
+  const configured = process.env.BYTEBOT_SHARED_STORAGE_PATH;
+  return configured ? resolve(configured) : DEFAULT_STORAGE_ROOT;
+}
+
+function sanitizeFileName(filename: string): string {
+  const trimmed = filename.trim();
+  const basename = trimmed.replace(/\\+/g, '/').split('/').pop() ?? 'file';
+  const { name, ext } = parse(basename);
+  const safeName = name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200) || 'file';
+  const safeExt = ext.replace(/[^a-zA-Z0-9._-]/g, '').slice(0, 25);
+  return `${safeName}${safeExt}`;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsPromises.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function generateUniquePath(directory: string, filename: string): Promise<string> {
+  let candidate = join(directory, filename);
+  const { name, ext } = parse(filename);
+  let attempt = 0;
+
+  while (await pathExists(candidate)) {
+    attempt += 1;
+    candidate = join(directory, `${name}-${attempt}${ext}`);
+  }
+
+  return candidate;
+}
+
+async function writeBase64ToFile(base64: string, destination: string) {
+  const stream = createWriteStream(destination, { mode: 0o600 });
+  try {
+    const chunkSize = 1024 * 512;
+    for (let offset = 0; offset < base64.length; offset += chunkSize) {
+      const chunk = base64.slice(offset, offset + chunkSize);
+      const buffer = Buffer.from(chunk, 'base64');
+      if (!stream.write(buffer)) {
+        await once(stream, 'drain');
+      }
+    }
+    stream.end();
+    await finished(stream);
+  } catch (error) {
+    stream.destroy();
+    await fsPromises.rm(destination, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function migrateForward(storageRoot: string, dryRun: boolean) {
+  console.log('Starting forward migration (database -> filesystem)');
+  const rows = await prisma.$queryRaw<FileRow[]>`
+    SELECT "id", "name", "taskId", "legacy_data" as "legacyData"
+    FROM "File"
+    WHERE COALESCE("storage_path", '') = ''
+    ORDER BY "createdAt" ASC
+  `;
+
+  console.log(`Found ${rows.length} file(s) requiring migration.`);
+
+  for (const row of rows) {
+    if (!row.legacyData) {
+      console.warn(`Skipping file ${row.id} (${row.name}) - no legacy data found.`);
+      continue;
+    }
+
+    const sanitized = sanitizeFileName(row.name);
+    const taskDirectory = join(storageRoot, row.taskId);
+    await fsPromises.mkdir(taskDirectory, { recursive: true });
+    const destination = await generateUniquePath(taskDirectory, sanitized);
+
+    if (!dryRun) {
+      await writeBase64ToFile(row.legacyData, destination);
+      const relativePath = relative(storageRoot, destination);
+      await prisma.$executeRawUnsafe(
+        'UPDATE "File" SET "storage_path" = $1, "legacy_data" = NULL, "updatedAt" = NOW() WHERE "id" = $2',
+        relativePath,
+        row.id,
+      );
+      console.log(`Migrated ${row.name} -> ${relativePath}`);
+    } else {
+      console.log(`[dry-run] Would migrate ${row.name} to ${destination}`);
+    }
+  }
+}
+
+async function migrateRollback(storageRoot: string, dryRun: boolean) {
+  console.log('Starting rollback migration (filesystem -> database)');
+  const rows = await prisma.$queryRaw<FileRow[]>`
+    SELECT "id", "name", "taskId", "storage_path" as "storagePath"
+    FROM "File"
+    WHERE COALESCE("storage_path", '') <> ''
+    ORDER BY "createdAt" ASC
+  `;
+
+  console.log(`Found ${rows.length} file(s) staged on disk.`);
+
+  for (const row of rows) {
+    if (!row.storagePath) {
+      console.warn(`Skipping file ${row.id} (${row.name}) - storage path missing.`);
+      continue;
+    }
+
+    const absolutePath = resolve(storageRoot, row.storagePath);
+    if (!(await pathExists(absolutePath))) {
+      console.warn(
+        `Skipping file ${row.id} (${row.name}) - expected file missing at ${absolutePath}.`,
+      );
+      continue;
+    }
+
+    if (!dryRun) {
+      const buffer = await fsPromises.readFile(absolutePath);
+      const base64 = buffer.toString('base64');
+      await prisma.$executeRawUnsafe(
+        'UPDATE "File" SET "legacy_data" = $1, "storage_path" = $2, "updatedAt" = NOW() WHERE "id" = $3',
+        base64,
+        '',
+        row.id,
+      );
+      console.log(`Restored ${row.name} from ${row.storagePath}`);
+    } else {
+      console.log(`[dry-run] Would restore ${row.name} from ${absolutePath}`);
+    }
+  }
+}
+
+async function main() {
+  const options = parseArgs();
+  const storageRoot = resolveStorageRoot();
+  console.log(`Using storage root: ${storageRoot}`);
+  await fsPromises.mkdir(storageRoot, { recursive: true });
+
+  if (options.direction === 'forward') {
+    await migrateForward(storageRoot, options.dryRun);
+  } else {
+    await migrateRollback(storageRoot, options.dryRun);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Migration failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/bytebot-agent/src/agent/agent.scheduler.ts
+++ b/packages/bytebot-agent/src/agent/agent.scheduler.ts
@@ -3,7 +3,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { TasksService } from '../tasks/tasks.service';
 import { AgentProcessor } from './agent.processor';
 import { TaskStatus } from '@prisma/client';
-import { writeFile } from './agent.computer-use';
+import { FileStorageService } from '../tasks/file-storage.service';
 
 @Injectable()
 export class AgentScheduler implements OnModuleInit {
@@ -12,6 +12,7 @@ export class AgentScheduler implements OnModuleInit {
   constructor(
     private readonly tasksService: TasksService,
     private readonly agentProcessor: AgentProcessor,
+    private readonly fileStorageService: FileStorageService,
   ) {}
 
   async onModuleInit() {
@@ -42,13 +43,34 @@ export class AgentScheduler implements OnModuleInit {
     if (task) {
       if (task.files.length > 0) {
         this.logger.debug(
-          `Task ID: ${task.id} has files, writing them to the desktop`,
+          `Task ID: ${task.id} has files, staging them from shared storage`,
         );
         for (const file of task.files) {
-          await writeFile({
-            path: `/home/user/Desktop/${file.name}`,
-            content: file.data, // file.data is already base64 encoded in the database
-          });
+          if (!file.storagePath) {
+            this.logger.warn(
+              `Skipping file ${file.name} for task ${task.id} because storagePath is missing`,
+            );
+            continue;
+          }
+
+          if (file.storageProvider !== this.fileStorageService.provider) {
+            this.logger.warn(
+              `Skipping file ${file.name} for task ${task.id} due to unsupported provider ${file.storageProvider}`,
+            );
+            continue;
+          }
+
+          try {
+            const destination = await this.fileStorageService.copyToDesktop(file);
+            this.logger.debug(
+              `Copied file ${file.name} for task ${task.id} to ${destination}`,
+            );
+          } catch (error) {
+            this.logger.error(
+              `Failed to prepare file ${file.name} for task ${task.id}: ${error.message}`,
+              error.stack,
+            );
+          }
         }
       }
 

--- a/packages/bytebot-agent/src/tasks/file-storage.service.ts
+++ b/packages/bytebot-agent/src/tasks/file-storage.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createWriteStream, promises as fsPromises } from 'fs';
+import { join, parse, relative, resolve } from 'path';
+import { once } from 'events';
+import { finished } from 'stream/promises';
+
+const DEFAULT_STORAGE_DIR = resolve('/var', 'bytebot', 'uploads');
+const DEFAULT_DESKTOP_DIR = '/home/user/Desktop';
+
+interface PersistedFileMetadata {
+  absolutePath: string;
+  relativePath: string;
+}
+
+@Injectable()
+export class FileStorageService {
+  private readonly logger = new Logger(FileStorageService.name);
+  private readonly storageRoot: string;
+  readonly provider = 'filesystem';
+
+  constructor(private readonly configService: ConfigService) {
+    const configuredRoot = this.configService.get<string>(
+      'BYTEBOT_SHARED_STORAGE_PATH',
+    );
+    this.storageRoot = configuredRoot
+      ? resolve(configuredRoot)
+      : DEFAULT_STORAGE_DIR;
+    this.logger.log(`Using shared storage root: ${this.storageRoot}`);
+  }
+
+  getStorageRoot(): string {
+    return this.storageRoot;
+  }
+
+  getDesktopMountPath(): string {
+    const configured = this.configService.get<string>(
+      'BYTEBOT_DESKTOP_MOUNT_PATH',
+    );
+    return configured ? resolve(configured) : DEFAULT_DESKTOP_DIR;
+  }
+
+  getAbsolutePath(relativePath: string): string {
+    return resolve(this.storageRoot, relativePath);
+  }
+
+  async persistBase64File(
+    taskId: string,
+    file: { name: string; base64: string },
+  ): Promise<PersistedFileMetadata> {
+    const base64Data = this.extractBase64Payload(file.base64);
+    const sanitizedName = this.sanitizeFileName(file.name);
+    const taskDirectory = join(this.storageRoot, taskId);
+    await fsPromises.mkdir(taskDirectory, { recursive: true });
+    const destinationPath = await this.generateUniquePath(
+      taskDirectory,
+      sanitizedName,
+    );
+
+    await this.writeBase64ToFile(base64Data, destinationPath);
+
+    const relativePath = relative(this.storageRoot, destinationPath);
+
+    return {
+      absolutePath: destinationPath,
+      relativePath,
+    };
+  }
+
+  async copyToDesktop(
+    file: { name: string; storagePath: string },
+  ): Promise<string> {
+    const absoluteSourcePath = this.getAbsolutePath(file.storagePath);
+    const desktopMount = this.getDesktopMountPath();
+    await fsPromises.mkdir(desktopMount, { recursive: true });
+    const destinationPath = await this.generateUniquePath(
+      desktopMount,
+      this.sanitizeFileName(file.name),
+    );
+
+    await fsPromises.copyFile(absoluteSourcePath, destinationPath);
+
+    return destinationPath;
+  }
+
+  private sanitizeFileName(filename: string): string {
+    const trimmed = filename.trim();
+    const basename = trimmed.replace(/\\+/g, '/').split('/').pop() ?? 'file';
+    const { name, ext } = parse(basename);
+    const safeName = name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200) || 'file';
+    const safeExt = ext.replace(/[^a-zA-Z0-9._-]/g, '').slice(0, 25);
+    return `${safeName}${safeExt}`;
+  }
+
+  private extractBase64Payload(base64: string): string {
+    if (base64.includes('base64,')) {
+      return base64.slice(base64.indexOf('base64,') + 'base64,'.length);
+    }
+
+    return base64;
+  }
+
+  private async writeBase64ToFile(data: string, destination: string) {
+    const stream = createWriteStream(destination, { mode: 0o600 });
+
+    try {
+      const chunkSize = 1024 * 512; // 512KB
+      for (let offset = 0; offset < data.length; offset += chunkSize) {
+        const chunk = data.slice(offset, offset + chunkSize);
+        const buffer = Buffer.from(chunk, 'base64');
+        if (!stream.write(buffer)) {
+          await once(stream, 'drain');
+        }
+      }
+      stream.end();
+      await finished(stream);
+    } catch (error) {
+      stream.destroy();
+      await this.safeRemove(destination);
+      throw error;
+    }
+  }
+
+  private async generateUniquePath(
+    directory: string,
+    filename: string,
+  ): Promise<string> {
+    let candidate = join(directory, filename);
+    const { name, ext } = parse(filename);
+    let attempt = 0;
+
+    while (await this.pathExists(candidate)) {
+      attempt += 1;
+      const nextName = `${name}-${attempt}${ext}`;
+      candidate = join(directory, nextName);
+    }
+
+    return candidate;
+  }
+
+  private async pathExists(target: string): Promise<boolean> {
+    try {
+      await fsPromises.access(target);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async safeRemove(target: string) {
+    try {
+      await fsPromises.rm(target, { force: true });
+    } catch (error) {
+      this.logger.warn(`Failed to cleanup temporary file ${target}: ${error}`);
+    }
+  }
+}

--- a/packages/bytebot-agent/src/tasks/tasks.module.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.module.ts
@@ -4,11 +4,12 @@ import { TasksService } from './tasks.service';
 import { TasksGateway } from './tasks.gateway';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MessagesModule } from '../messages/messages.module';
+import { FileStorageService } from './file-storage.service';
 
 @Module({
   imports: [PrismaModule, MessagesModule],
   controllers: [TasksController],
-  providers: [TasksService, TasksGateway],
-  exports: [TasksService, TasksGateway],
+  providers: [TasksService, TasksGateway, FileStorageService],
+  exports: [TasksService, TasksGateway, FileStorageService],
 })
 export class TasksModule {}

--- a/packages/bytebot-agent/src/tasks/tasks.service.spec.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.service.spec.ts
@@ -65,12 +65,17 @@ describe('TasksService', () => {
     const tasksGateway = {};
     const configService = {};
     const eventEmitter = { emit: jest.fn() };
+    const fileStorageService = {
+      persistBase64File: jest.fn(),
+      provider: 'filesystem',
+    };
 
     const service = new TasksService(
       prisma as any,
       tasksGateway as any,
       configService as any,
       eventEmitter as any,
+      fileStorageService as any,
     );
 
     return { service, prisma };


### PR DESCRIPTION
## Summary
- stream task file uploads to a shared filesystem via a new FileStorageService and persist only metadata in Prisma
- update agent schedulers to copy staged files into the desktop mount and add matching Prisma migrations
- add a data migration script with documentation for moving legacy base64 blobs to disk and supporting rollback

## Testing
- npm run build --prefix packages/shared
- npm test (from packages/bytebot-agent)


------
https://chatgpt.com/codex/tasks/task_e_68d0f59e0a008323ba5d3ae8878919c3