### PR TITLE
Handle thinking blocks in token estimation

### DIFF
--- a/packages/bytebot-agent/src/messages/messages.tokens.spec.ts
+++ b/packages/bytebot-agent/src/messages/messages.tokens.spec.ts
@@ -1,0 +1,64 @@
+import {
+  MessageContentType,
+  RedactedThinkingContentBlock,
+  ThinkingContentBlock,
+} from '@bytebot/shared';
+import {
+  estimateMessageTokenCount,
+  estimateTokensForBlock,
+  estimateTokensFromText,
+} from './messages.tokens';
+
+describe('messages.tokens', () => {
+  describe('estimateTokensForBlock', () => {
+    it('uses textual estimation for thinking blocks', () => {
+      const thinking = 'Thought step '.repeat(50);
+      const block: ThinkingContentBlock = {
+        type: MessageContentType.Thinking,
+        thinking,
+        signature: 'signature',
+      };
+
+      const expected = estimateTokensFromText(thinking);
+      const tokens = estimateTokensForBlock(block);
+
+      expect(tokens).toBe(expected);
+      expect(tokens).toBeGreaterThan(estimateTokensFromText('thought'));
+    });
+
+    it('uses textual estimation for redacted thinking blocks', () => {
+      const data = 'REDACTED '.repeat(40);
+      const block: RedactedThinkingContentBlock = {
+        type: MessageContentType.RedactedThinking,
+        data,
+      };
+
+      const expected = estimateTokensFromText(data);
+      const tokens = estimateTokensForBlock(block);
+
+      expect(tokens).toBe(expected);
+      expect(tokens).toBeGreaterThan(0);
+    });
+  });
+
+  describe('estimateMessageTokenCount', () => {
+    it('returns a large count for messages with long thinking content', () => {
+      const thinking = 'Deep reasoning step '.repeat(500);
+      const block: ThinkingContentBlock = {
+        type: MessageContentType.Thinking,
+        thinking,
+        signature: 'signature',
+      };
+
+      const estimate = estimateMessageTokenCount([
+        { content: [block] },
+      ]);
+
+      const expected = estimateTokensFromText(thinking);
+
+      expect(estimate.totalTokens).toBe(expected);
+      expect(estimate.recentWindowTokens).toBe(expected);
+      expect(estimate.totalTokens).toBeGreaterThan(2000);
+    });
+  });
+});

--- a/packages/bytebot-agent/src/messages/messages.tokens.ts
+++ b/packages/bytebot-agent/src/messages/messages.tokens.ts
@@ -1,0 +1,194 @@
+import {
+  MessageContentBlock,
+  MessageContentType,
+  isMessageContentBlock,
+} from '@bytebot/shared';
+
+const CHARACTERS_PER_TOKEN = 4;
+const DEFAULT_BLOCK_TOKEN_ESTIMATE = 32;
+const IMAGE_BLOCK_TOKEN_ESTIMATE = 1024;
+const SCALAR_TOKEN_ESTIMATE = 4;
+
+export interface MessageLike {
+  content?: MessageContentBlock[] | null;
+}
+
+export interface EstimateMessageTokenCountOptions {
+  /**
+   * Maximum number of messages to include when calculating the recent window.
+   * Defaults to 10 to keep the most recent conversational context.
+   */
+  recentWindowMessageCount?: number;
+  /**
+   * Approximate token budget for the recent window. When exceeded we stop
+   * including older messages in the recent portion.
+   */
+  recentWindowTokenLimit?: number;
+}
+
+export interface EstimatedMessageTokenCount {
+  totalTokens: number;
+  recentWindowTokens: number;
+  averageTokensPerMessage: number;
+  messageCount: number;
+}
+
+export function estimateTokensFromText(text?: string | null): number {
+  if (!text) {
+    return 0;
+  }
+
+  const cleaned = text.trim();
+  if (!cleaned) {
+    return 0;
+  }
+
+  return Math.max(1, Math.ceil(cleaned.length / CHARACTERS_PER_TOKEN));
+}
+
+export function estimateTokensForBlock(block: MessageContentBlock): number {
+  let tokens = 0;
+
+  switch (block.type) {
+    case MessageContentType.Text:
+      tokens += estimateTokensFromText(block.text);
+      break;
+    case MessageContentType.Thinking:
+      tokens += estimateTokensFromText(block.thinking);
+      break;
+    case MessageContentType.RedactedThinking:
+      tokens += estimateTokensFromText(block.data);
+      break;
+    case MessageContentType.Image:
+      tokens += IMAGE_BLOCK_TOKEN_ESTIMATE;
+      break;
+    case MessageContentType.Document: {
+      const dataTokens = block.source?.data
+        ? Math.ceil(block.source.data.length / 8)
+        : 0;
+      const nameTokens = estimateTokensFromText(block.name);
+      tokens += Math.max(dataTokens + nameTokens, DEFAULT_BLOCK_TOKEN_ESTIMATE);
+      break;
+    }
+    case MessageContentType.ToolUse:
+      tokens += estimateTokensFromText(block.name);
+      tokens += estimateTokensFromText(block.id);
+      tokens += estimateTokensFromUnknown(block.input);
+      break;
+    case MessageContentType.ToolResult:
+      tokens += estimateTokensFromText(block.tool_use_id);
+      break;
+    case MessageContentType.UserAction:
+      // User action blocks primarily wrap other content. Use a small base cost
+      // to reflect the structural metadata.
+      tokens += SCALAR_TOKEN_ESTIMATE;
+      break;
+    default:
+      tokens += estimateTokensFromUnknown(stripContent(block));
+      break;
+  }
+
+  if (Array.isArray(block.content) && block.content.length > 0) {
+    tokens += block.content.reduce(
+      (sum, nested) => sum + estimateTokensForBlock(nested),
+      0,
+    );
+  }
+
+  return tokens || DEFAULT_BLOCK_TOKEN_ESTIMATE;
+}
+
+export function estimateTokensForMessage(
+  content?: MessageContentBlock[] | null,
+): number {
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+
+  return content.reduce((sum, block) => sum + estimateTokensForBlock(block), 0);
+}
+
+export function estimateMessageTokenCount(
+  messages: MessageLike[],
+  options: EstimateMessageTokenCountOptions = {},
+): EstimatedMessageTokenCount {
+  const recentWindowMessageCount = options.recentWindowMessageCount ?? 10;
+  const recentWindowTokenLimit = options.recentWindowTokenLimit ?? 4000;
+
+  const messageTokens = messages.map(message =>
+    estimateTokensForMessage(message.content),
+  );
+
+  const totalTokens = messageTokens.reduce((sum, value) => sum + value, 0);
+
+  let recentWindowTokens = 0;
+  let includedMessages = 0;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (includedMessages >= recentWindowMessageCount) {
+      break;
+    }
+
+    const tokens = messageTokens[index];
+    if (recentWindowTokens + tokens > recentWindowTokenLimit) {
+      recentWindowTokens = recentWindowTokenLimit;
+      break;
+    }
+
+    recentWindowTokens += tokens;
+    includedMessages += 1;
+  }
+
+  recentWindowTokens = Math.min(recentWindowTokens, totalTokens);
+
+  const averageTokensPerMessage =
+    messages.length === 0 ? 0 : totalTokens / messages.length;
+
+  return {
+    totalTokens,
+    recentWindowTokens,
+    averageTokensPerMessage,
+    messageCount: messages.length,
+  };
+}
+
+function estimateTokensFromUnknown(value: unknown, visited = new WeakSet<object>()): number {
+  if (typeof value === 'string') {
+    return estimateTokensFromText(value);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return SCALAR_TOKEN_ESTIMATE;
+  }
+
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (sum, item) => sum + estimateTokensFromUnknown(item, visited),
+      0,
+    );
+  }
+
+  if (!value || typeof value !== 'object') {
+    return 0;
+  }
+
+  if (visited.has(value as object)) {
+    return 0;
+  }
+
+  visited.add(value as object);
+
+  if (isMessageContentBlock(value)) {
+    return estimateTokensForBlock(value);
+  }
+
+  return Object.values(value).reduce(
+    (sum, item) => sum + estimateTokensFromUnknown(item, visited),
+    0,
+  );
+}
+
+function stripContent(block: MessageContentBlock): Record<string, unknown> {
+  const { content, ...rest } = block as { content?: unknown } & Record<string, unknown>;
+  return rest;
+}


### PR DESCRIPTION
## Summary
- add message token estimation utilities that count textual reasoning content instead of falling back to a constant
- ensure recent window calculations account for nested content blocks when estimating message tokens
- add unit coverage for thinking and redacted thinking blocks so long reasoning produces large token estimates

## Testing
- npm run build --prefix packages/shared
- npm test --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68d18698f530832382297fd5e01be296