### PR TITLE
Make file storage metadata optional

### DIFF
--- a/packages/bytebot-agent/prisma/migrations/20250910120000_optional_file_data_nullable/migration.sql
+++ b/packages/bytebot-agent/prisma/migrations/20250910120000_optional_file_data_nullable/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "File"
+    ADD COLUMN IF NOT EXISTS "storage_path" TEXT,
+    ADD COLUMN IF NOT EXISTS "storage_provider" TEXT;
+
+UPDATE "File"
+SET "storage_path" = NULLIF("storage_path", '')
+WHERE "storage_path" IS NOT NULL;
+
+UPDATE "File"
+SET "storage_provider" = COALESCE("storage_provider", 'filesystem')
+WHERE "storage_provider" IS NULL;
+
+ALTER TABLE "File"
+    ALTER COLUMN "storage_path" DROP NOT NULL,
+    ALTER COLUMN "storage_provider" DROP NOT NULL,
+    ALTER COLUMN "legacy_data" DROP NOT NULL;

--- a/packages/bytebot-agent/prisma/schema.prisma
+++ b/packages/bytebot-agent/prisma/schema.prisma
@@ -103,9 +103,9 @@ model File {
   name             String
   type             String // MIME type
   size             Int // Size in bytes
-  storagePath      String  @map("storage_path")
-  storageProvider  String  @default("filesystem") @map("storage_provider")
-  legacyData       String? @map("legacy_data") @db.Text @ignore
+  storagePath      String? @map("storage_path")
+  storageProvider  String? @map("storage_provider")
+  data             String? @map("legacy_data") @db.Text
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- allow nullable storage metadata and optional legacy data on the File model
- add migration to relax File constraints and normalize existing records

## Testing
- npm run prisma:dev *(fails: missing DATABASE_URL in container)*
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68d1898adf9c8323b9c4b3d84918cf32