### PR TITLE
Build agent app before prod start

### DIFF
--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -13,7 +13,7 @@
     "start": "npm run build --prefix ../shared && nest start",
     "start:dev": "npm run build --prefix ../shared && nest start --watch",
     "start:debug": "npm run build --prefix ../shared && nest start --debug --watch",
-    "start:prod": "npm run build --prefix ../shared && npx prisma migrate deploy && npx prisma generate && node dist/main",
+    "start:prod": "npm run build --prefix ../shared && npx prisma migrate deploy && npx prisma generate && nest build && node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- ensure the bytebot-agent production start script compiles the NestJS app before launching
- keep the existing Prisma migration and generation steps while adding an explicit build

## Testing
- npm run start:prod *(fails: Prisma requires DATABASE_URL to run migrations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18eeebc1483239998681a59aa73cc