### PR TITLE
Restrict bytebot agent build to src outputs

### DIFF
--- a/packages/bytebot-agent/tsconfig.build.json
+++ b/packages/bytebot-agent/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- scope the bytebot agent build to the NestJS source directory by setting the build config rootDir and include

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68d19606f2d883238e49c84534174325