### PR TITLE
Point prod start script to compiled bundle

### DIFF
--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -13,7 +13,7 @@
     "start": "npm run build --prefix ../shared && nest start",
     "start:dev": "npm run build --prefix ../shared && nest start --watch",
     "start:debug": "npm run build --prefix ../shared && nest start --debug --watch",
-    "start:prod": "npm run build --prefix ../shared && npx prisma migrate deploy && npx prisma generate && nest build && node dist/main",
+    "start:prod": "npm run build --prefix ../shared && npx prisma migrate deploy && npx prisma generate && nest build && node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- update the production start script to execute the compiled NestJS entrypoint with its .js extension

## Testing
- npm run start:prod *(fails: Prisma migrate requires DATABASE_URL in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a3aff8048323bd5d305c315ba518