### PR TITLE
Ensure universal coordinate config discovery works in packaged builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The Hawkeye edition layers precision-oriented upgrades on top of upstream Bytebo
 - **Progressive zoom capture** lets the agent request focused screenshots with cyan micro-grids so it can translate local coordinates back into global positions with 100% verified accuracy.
 - **Measured accuracy gains** combine the overlay, zoom pipeline, and calibration passes to reach ~70% coordinate precision in testing—check out the full breakdown in [Coordinate Accuracy Improvements](COORDINATE_ACCURACY_IMPROVEMENTS.md).
 - **Feature toggles** let you dial these systems back when needed. Set `BYTEBOT_UNIVERSAL_TEACHING`, `BYTEBOT_ADAPTIVE_CALIBRATION`, `BYTEBOT_ZOOM_REFINEMENT`, or `BYTEBOT_COORDINATE_METRICS` to `false` (all default to `true`) to selectively disable overlays, calibration passes, zoom refinement, and telemetry capture.
+- **Universal coordinate mapping** now ships with the repo and the shared workspace package. Services automatically walk up from their working directory (and the bundled copy in `@bytebot/shared`) to locate `config/universal-coordinates.yaml`, so you only need `BYTEBOT_COORDINATE_CONFIG` when pointing at a custom YAML.
 
 ### Smart Focus Targeting (Hawkeye Exclusive)
 

--- a/config/universal-coordinates.yaml
+++ b/config/universal-coordinates.yaml
@@ -1,0 +1,18 @@
+# Bytebot universal coordinate mapping
+version: 1
+viewport:
+  width: 1920
+  height: 1080
+referencePoints:
+  topLeft:
+    x: 0
+    y: 0
+  topRight:
+    x: 1919
+    y: 0
+  bottomLeft:
+    x: 0
+    y: 1079
+  bottomRight:
+    x: 1919
+    y: 1079

--- a/packages/bytebotd/package.json
+++ b/packages/bytebotd/package.json
@@ -25,6 +25,7 @@
     "prestart:prod": "npm run shared:build",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "pretest": "npm run shared:build",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/packages/bytebotd/src/config/universal-coordinates.config.spec.ts
+++ b/packages/bytebotd/src/config/universal-coordinates.config.spec.ts
@@ -1,0 +1,29 @@
+import * as path from 'node:path';
+
+import { resolveConfigPath } from '@bytebot/shared';
+
+describe('Universal coordinate config discovery', () => {
+  const originalOverride = process.env.BYTEBOT_COORDINATE_CONFIG;
+
+  beforeEach(() => {
+    delete process.env.BYTEBOT_COORDINATE_CONFIG;
+  });
+
+  afterAll(() => {
+    if (originalOverride === undefined) {
+      delete process.env.BYTEBOT_COORDINATE_CONFIG;
+    } else {
+      process.env.BYTEBOT_COORDINATE_CONFIG = originalOverride;
+    }
+  });
+
+  it('resolves the repository-level YAML without requiring BYTEBOT_COORDINATE_CONFIG', () => {
+    const resolvedPath = resolveConfigPath();
+    const expectedPath = path.resolve(
+      __dirname,
+      '../../../../config/universal-coordinates.yaml',
+    );
+
+    expect(resolvedPath).toBe(expectedPath);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node ./scripts/copy-universal-coordinate-config.cjs",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint \"src/**/*.ts\" --fix",
     "prepublishOnly": "npm run build"

--- a/packages/shared/scripts/copy-universal-coordinate-config.cjs
+++ b/packages/shared/scripts/copy-universal-coordinate-config.cjs
@@ -1,0 +1,19 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoConfigPath = path.resolve(
+  __dirname,
+  '../../..',
+  'config/universal-coordinates.yaml',
+);
+const distConfigDir = path.resolve(__dirname, '..', 'dist', 'config');
+const distConfigPath = path.join(distConfigDir, 'universal-coordinates.yaml');
+
+if (!fs.existsSync(repoConfigPath)) {
+  throw new Error(
+    `Expected universal coordinate config at ${repoConfigPath} but the file is missing.`,
+  );
+}
+
+fs.mkdirSync(distConfigDir, { recursive: true });
+fs.copyFileSync(repoConfigPath, distConfigPath);

--- a/packages/shared/src/config/universalCoordinates.ts
+++ b/packages/shared/src/config/universalCoordinates.ts
@@ -1,0 +1,78 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const CONFIG_FILE_NAME = 'universal-coordinates.yaml';
+const CONFIG_RELATIVE_PATH = path.join('config', CONFIG_FILE_NAME);
+
+type SearchResult = string | null;
+
+const searchUpwards = (start: string): SearchResult => {
+  let current = path.resolve(start);
+  const visited = new Set<string>();
+
+  while (!visited.has(current)) {
+    visited.add(current);
+
+    const candidate = path.join(current, CONFIG_RELATIVE_PATH);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+
+    current = parent;
+  }
+
+  return null;
+};
+
+const resolveOverridePath = (candidate: string): string => {
+  const resolvedPath = path.isAbsolute(candidate)
+    ? candidate
+    : path.resolve(process.cwd(), candidate);
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(
+      `BYTEBOT_COORDINATE_CONFIG points to \"${candidate}\" but the file was not found.`,
+    );
+  }
+
+  return resolvedPath;
+};
+
+export const resolveConfigPath = (): string => {
+  const override = process.env.BYTEBOT_COORDINATE_CONFIG;
+  if (override && override.trim().length > 0) {
+    return resolveOverridePath(override.trim());
+  }
+
+  const searchOrigins = [process.cwd(), __dirname];
+  const checked = new Set<string>();
+
+  for (const origin of searchOrigins) {
+    const resolvedOrigin = path.resolve(origin);
+    if (checked.has(resolvedOrigin)) {
+      continue;
+    }
+
+    checked.add(resolvedOrigin);
+    const discovered = searchUpwards(resolvedOrigin);
+    if (discovered) {
+      return discovered;
+    }
+  }
+
+  throw new Error(
+    'Unable to locate config/universal-coordinates.yaml. Set BYTEBOT_COORDINATE_CONFIG to override the search location.',
+  );
+};
+
+export const readUniversalCoordinateConfig = (): string => {
+  const configPath = resolveConfigPath();
+  return fs.readFileSync(configPath, 'utf8');
+};
+
+export const UNIVERSAL_COORDINATE_CONFIG_PATH = CONFIG_RELATIVE_PATH;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from "./utils/messageContent.utils";
 export * from "./utils/computerAction.utils";
 export * from "./types/computerAction.types";
 export * from "./constants/agent.constants";
+export * from "./config/universalCoordinates";

--- a/packages/shared/src/types/node-globals.d.ts
+++ b/packages/shared/src/types/node-globals.d.ts
@@ -1,0 +1,25 @@
+declare module 'node:fs' {
+  const fs: {
+    existsSync: (path: string) => boolean;
+    readFileSync: (path: string, options: string) => string;
+    mkdirSync: (path: string, options: { recursive: boolean }) => void;
+    copyFileSync: (src: string, dest: string) => void;
+  };
+  export = fs;
+}
+
+declare module 'node:path' {
+  const path: {
+    resolve: (...segments: string[]) => string;
+    join: (...segments: string[]) => string;
+    dirname: (segment: string) => string;
+    isAbsolute: (segment: string) => boolean;
+  };
+  export = path;
+}
+
+declare const __dirname: string;
+declare const process: {
+  cwd: () => string;
+  env: Record<string, string | undefined>;
+};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Summary
- add a repository-level `config/universal-coordinates.yaml` and expose helpers from `@bytebot/shared` that walk up from both the service cwd and the shared package directory to locate it
- copy the YAML into the shared package’s dist folder during build and add lightweight node shims so TypeScript compiles without external type downloads
- cover the discovery path from the bytebotd tests, ensure shared gets built before Jest runs, and update the README to document the new default lookup behaviour

## Testing
- npm test --prefix packages/bytebotd

------
https://chatgpt.com/codex/tasks/task_e_68d1a42e84148323b14176c8a4d51e7b