### PR TITLE
Refine universal coordinate loader typing

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,11 @@
     ".": {
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
+    },
+    "./config/universalCoordinates": {
+      "types": "./dist/config/universalCoordinates.d.ts",
+      "import": "./dist/config/universalCoordinates.js",
+      "require": "./dist/config/universalCoordinates.js"
     }
   },
   "devDependencies": {

--- a/packages/shared/src/config/universalCoordinates.ts
+++ b/packages/shared/src/config/universalCoordinates.ts
@@ -1,0 +1,140 @@
+import { access, readFile } from 'fs/promises';
+import path from 'path';
+
+export type UniversalCoordinatesConfig = unknown;
+
+export interface LoadUniversalCoordinatesOptions {
+  /**
+   * Additional candidate file paths to check before the defaults.
+   * Relative paths are resolved against `cwd` (or `process.cwd()` when omitted).
+   */
+  candidates?: string[];
+  /**
+   * Base directory used to resolve relative paths supplied via `candidates`.
+   * Defaults to the current working directory at call time.
+   */
+  cwd?: string;
+}
+
+type ErrnoException = Error & { code?: string };
+
+type ProcessLike = {
+  cwd(): string;
+  env?: Record<string, string | undefined>;
+};
+
+const DEFAULT_RELATIVE_PATHS = [
+  path.join('config', 'universal-coordinates.json'),
+  'universal-coordinates.json',
+];
+
+function getProcess(): ProcessLike {
+  const processLike = (globalThis as { process?: ProcessLike }).process;
+  if (!processLike) {
+    throw new Error('Process is not available in this environment.');
+  }
+  return processLike;
+}
+
+function normaliseCandidates(candidates: string[] = [], cwd: string): string[] {
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    const resolved = path.isAbsolute(trimmed)
+      ? path.normalize(trimmed)
+      : path.normalize(path.join(cwd, trimmed));
+    if (!seen.has(resolved)) {
+      seen.add(resolved);
+    }
+  }
+
+  return Array.from(seen);
+}
+
+function buildSearchPaths(
+  options: LoadUniversalCoordinatesOptions = {},
+): string[] {
+  const nodeProcess = getProcess();
+  const cwd = options.cwd ?? nodeProcess.cwd();
+  const envPath = nodeProcess.env?.BYTEBOT_UNIVERSAL_COORDINATES_PATH;
+
+  const explicit = normaliseCandidates(options.candidates, cwd);
+  const environment = envPath ? normaliseCandidates([envPath], cwd) : [];
+  const defaults = normaliseCandidates(DEFAULT_RELATIVE_PATHS, cwd);
+
+  return [...explicit, ...environment, ...defaults];
+}
+
+export async function findUniversalCoordinatesPath(
+  options: LoadUniversalCoordinatesOptions = {},
+): Promise<string | null> {
+  const searchPaths = buildSearchPaths(options);
+
+  for (const candidate of searchPaths) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch (error) {
+      const err = error as ErrnoException;
+      if (err.code === 'ENOENT') {
+        continue;
+      }
+      throw new Error(
+        `Unable to access universal coordinate file at "${candidate}": ${err.message}`,
+      );
+    }
+  }
+
+  return null;
+}
+
+export async function loadUniversalCoordinates<T = UniversalCoordinatesConfig>(
+  options: LoadUniversalCoordinatesOptions = {},
+): Promise<T> {
+  const searchPaths = buildSearchPaths(options);
+  const errors: Error[] = [];
+
+  for (const candidate of searchPaths) {
+    try {
+      const fileContents = await readFile(candidate, 'utf8');
+      return JSON.parse(fileContents) as T;
+    } catch (error) {
+      const err = error as ErrnoException;
+      if (err.code === 'ENOENT') {
+        errors.push(
+          new Error(`Universal coordinate file not found at "${candidate}"`),
+        );
+        continue;
+      }
+
+      throw new Error(
+        `Failed to load universal coordinate file at "${candidate}": ${err.message}`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    const messageLines = errors.map((err) => `  - ${err.message}`);
+    throw new Error(
+      [
+        'Unable to locate a universal coordinate configuration file.',
+        'Checked the following paths:',
+        ...messageLines,
+        'Set BYTEBOT_UNIVERSAL_COORDINATES_PATH or provide an explicit path via options.',
+      ].join('\n'),
+    );
+  }
+
+  throw new Error(
+    'No universal coordinate configuration paths were provided to search.',
+  );
+}
+
+export function getDefaultUniversalCoordinatePaths(
+  cwd: string = getProcess().cwd(),
+): string[] {
+  return normaliseCandidates(DEFAULT_RELATIVE_PATHS, cwd);
+}

--- a/packages/shared/src/types/node-stubs.d.ts
+++ b/packages/shared/src/types/node-stubs.d.ts
@@ -1,0 +1,13 @@
+declare module 'fs/promises' {
+  export function access(path: string, mode?: number): Promise<void>;
+  export function readFile(
+    path: string,
+    options: { encoding: 'utf8' } | 'utf8',
+  ): Promise<string>;
+}
+
+declare module 'path' {
+  export function join(...parts: string[]): string;
+  export function normalize(path: string): string;
+  export function isAbsolute(path: string): boolean;
+}


### PR DESCRIPTION
## Summary
- guard the universal coordinate loader against missing global process references and rely on a helper for env access
- trim the shared package's Node stubs to avoid conflicts with real `@types/node` consumers while keeping TypeScript happy in the sandbox

## Testing
- npm run build --prefix packages/shared
- npm run build --prefix packages/bytebot-agent
- npm run build --prefix packages/bytebotd
- npm run build --prefix packages/bytebot-ui *(fails: Next.js CLI not available in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a42bc0e883238fbad436346eee49