### PR TITLE
Fix agent Docker builds to include universal config

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   bytebot-desktop:
     # Build from source
     build:
-      context: ../packages/
-      dockerfile: bytebotd/Dockerfile
+      context: ..
+      dockerfile: packages/bytebotd/Dockerfile
     # Use pre-built image
     image: ghcr.io/bytebot-ai/bytebot-desktop:edge
     shm_size: "2g"
@@ -57,8 +57,8 @@ services:
 
   bytebot-agent:
     build:
-      context: ../packages/
-      dockerfile: bytebot-agent/Dockerfile
+      context: ..
+      dockerfile: packages/bytebot-agent/Dockerfile
     # Use pre-built image
     image: ghcr.io/bytebot-ai/bytebot-agent:edge
     container_name: bytebot-agent
@@ -86,8 +86,8 @@ services:
 
   bytebot-ui:
     build:
-      context: ../packages/
-      dockerfile: bytebot-ui/Dockerfile
+      context: ..
+      dockerfile: packages/bytebot-ui/Dockerfile
       args:
         - BYTEBOT_AGENT_BASE_URL=${BYTEBOT_AGENT_BASE_URL:-http://bytebot-agent:9991}
         - BYTEBOT_DESKTOP_VNC_URL=${BYTEBOT_DESKTOP_VNC_URL:-http://bytebot-desktop:9990/websockify}

--- a/packages/bytebot-agent-cc/Dockerfile
+++ b/packages/bytebot-agent-cc/Dockerfile
@@ -5,8 +5,9 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy app source
-COPY ./shared ./shared
-COPY ./bytebot-agent-cc/ ./bytebot-agent-cc/
+COPY ./packages/shared ./shared
+COPY ./packages/bytebot-agent-cc/ ./bytebot-agent-cc/
+COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
 
 WORKDIR /app/bytebot-agent-cc
 

--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -5,8 +5,9 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy app source
-COPY ./shared ./shared
-COPY ./bytebot-agent/ ./bytebot-agent/
+COPY ./packages/shared ./shared
+COPY ./packages/bytebot-agent/ ./bytebot-agent/
+COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
 
 WORKDIR /app/bytebot-agent
 


### PR DESCRIPTION
## Summary
- point docker compose build contexts for source services at the repo root so Docker builds can access shared configuration files
- copy the universal coordinates config into the bytebot-agent and bytebot-agent-cc images so build scripts can find it

## Testing
- npm install --prefix packages/shared
- npm run build --prefix packages/shared

------
https://chatgpt.com/codex/tasks/task_e_68d1b2b784a0832396e7a94b350c4ab3