### PR TITLE
Ignore generated grid service outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,9 @@ lerna-debug.log*
 
 # Tests
 agent/coverage
+
+# Generated overlay samples
+packages/bytebotd/test-*-grid-service-output.png
 agent/.nyc_output
 
 # IDEs and editors


### PR DESCRIPTION
## Summary
- add a .gitignore rule to keep grid service overlay samples from being tracked

## Testing
- npm run build
- node test-grid.js (fails: libXtst.so.6 missing in container)

------
https://chatgpt.com/codex/tasks/task_e_68d1b50fb2a88323be1c33b725bd3da6