### PR TITLE
Handle string coordinate fields in parser

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
@@ -1,0 +1,25 @@
+import { CoordinateParser } from './coordinate-parser';
+
+describe('CoordinateParser', () => {
+  let parser: CoordinateParser;
+
+  beforeEach(() => {
+    parser = new CoordinateParser();
+  });
+
+  it('parses string valued global coordinates', () => {
+    const { global } = parser.parse('{"global": {"x": "120", "y": "40"}}');
+
+    expect(global).toEqual({ x: 120, y: 40 });
+  });
+
+  it('parses string valued alternative coordinate keys', () => {
+    const payload = JSON.stringify({
+      global: { globalX: '860.2px', globalY: '660.4' },
+    });
+
+    const { global } = parser.parse(payload);
+
+    expect(global).toEqual({ x: 860, y: 660 });
+  });
+});


### PR DESCRIPTION
## Summary
- coerce numeric string coordinate properties before parsing so alternatives like globalX work
- add coordinate parser unit tests covering string-based coordinate payloads

## Testing
- npm test -- coordinate-parser

------
https://chatgpt.com/codex/tasks/task_e_68d1bae337ec832390893446f16251c6