### PR TITLE
Expand calibration samples with metadata

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/index.ts
+++ b/packages/bytebot-agent/src/coordinate-system/index.ts
@@ -5,7 +5,7 @@ import {
   ScreenshotResponse,
   SmartClickAI,
 } from '../agent/smart-click.types';
-import { Calibrator } from './calibrator';
+import { Calibrator, RecordCorrectionOptions } from './calibrator';
 import { CoordinateParser } from './coordinate-parser';
 import { CoordinateTeacher } from './coordinate-teacher';
 import {
@@ -75,8 +75,12 @@ export class UniversalCoordinateSystem {
   recordCorrection(
     actual: Coordinates,
     predicted: Coordinates,
-    source?: string,
+    options?: RecordCorrectionOptions,
   ) {
-    return this.calibrator.recordCorrection(actual, predicted, source);
+    return this.calibrator.recordCorrection(
+      actual,
+      predicted,
+      options ?? 'correction',
+    );
   }
 }


### PR DESCRIPTION
## Summary
- enrich calibration samples with predicted/actual coordinates, success flag, target description, and precomputed error metadata
- propagate extended metadata through correction recording so calibration history can distinguish successful and failed clicks
- expose enhanced correction options via coordinate system entry point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1bfeb07f88323a6c7d63c3dddc25b