### PR TITLE
Add zoom overlay banner and mapping annotations

### DIFF
--- a/packages/bytebotd/src/nut/zoom-screenshot.service.spec.ts
+++ b/packages/bytebotd/src/nut/zoom-screenshot.service.spec.ts
@@ -1,0 +1,49 @@
+import { GridOverlayService } from './grid-overlay.service';
+import {
+  CoordinateMapping,
+  ZoomOptions,
+  ZoomScreenshotService,
+} from './zoom-screenshot.service';
+
+describe('ZoomScreenshotService - createZoomedGridSVG', () => {
+  let service: ZoomScreenshotService;
+
+  beforeEach(() => {
+    service = new ZoomScreenshotService(new GridOverlayService());
+  });
+
+  it('renders zoom banner, region offsets, and transform examples', () => {
+    const mapping: CoordinateMapping = {
+      localToGlobal: (localX: number, localY: number) => ({
+        x: 100 + localX / 4,
+        y: 200 + localY / 4,
+      }),
+      globalToLocal: (globalX: number, globalY: number) => ({
+        x: (globalX - 100) * 4,
+        y: (globalY - 200) * 4,
+      }),
+      region: { x: 100, y: 200, width: 400, height: 300 },
+      zoomLevel: 4,
+    };
+
+    const options: ZoomOptions = {
+      enableGrid: true,
+      gridSize: 50,
+      showGlobalCoordinates: true,
+      zoomLevel: mapping.zoomLevel,
+    };
+
+    const svg = (service as any).createZoomedGridSVG(
+      400,
+      300,
+      mapping,
+      options,
+      1920,
+      1080,
+    ) as string;
+
+    expect(svg).toContain('4X ZOOM');
+    expect(svg).toContain('Region starts at (100,200)');
+    expect(svg).toContain('Local(120,80) + Offset = Global(130,220)');
+  });
+});

--- a/packages/bytebotd/src/nut/zoom-screenshot.service.ts
+++ b/packages/bytebotd/src/nut/zoom-screenshot.service.ts
@@ -251,6 +251,23 @@ export class ZoomScreenshotService {
     // Add zoom level indicator
     svgContent += `<text x="${width/2}" y="${fontSize + 2}" text-anchor="middle" fill="${textColor}" fill-opacity="1.0" font-size="${fontSize + 2}px">ZOOM: ${mapping.zoomLevel}x | REGION: ${mapping.region.width}×${mapping.region.height}</text>`;
 
+    const zoomBannerLabel = `${mapping.zoomLevel.toFixed(0)}X ZOOM`;
+    const regionStartLabel = `Region starts at (${Math.round(mapping.region.x)},${Math.round(mapping.region.y)})`;
+    const sampleLocalPoint = { x: 120, y: 80 };
+    const sampleGlobalPoint = mapping.localToGlobal(
+      sampleLocalPoint.x,
+      sampleLocalPoint.y,
+    );
+    const transformExampleLabel = `Local(${sampleLocalPoint.x},${sampleLocalPoint.y}) + Offset = Global(${Math.round(sampleGlobalPoint.x)},${Math.round(sampleGlobalPoint.y)})`;
+
+    const bannerY = fontSize * 3;
+    const regionInfoY = bannerY + fontSize * 1.5;
+    const transformInfoY = regionInfoY + fontSize * 1.5;
+
+    svgContent += `<text x="${width / 2}" y="${bannerY}" text-anchor="middle" fill="${textColor}" fill-opacity="1.0" font-size="${fontSize + 8}px">${zoomBannerLabel}</text>`;
+    svgContent += `<text x="${width / 2}" y="${regionInfoY}" text-anchor="middle" fill="${textColor}" fill-opacity="${textOpacity}" font-size="${fontSize + 2}px">${regionStartLabel}</text>`;
+    svgContent += `<text x="${width / 2}" y="${transformInfoY}" text-anchor="middle" fill="${textColor}" fill-opacity="${textOpacity}" font-size="${fontSize + 2}px">${transformExampleLabel}</text>`;
+
     svgContent += '</g>';
     svgContent += '</svg>';
 


### PR DESCRIPTION
## Summary
- render additional zoom overlay labels showing zoom banner, region offsets, and a sample transform
- add a unit test around createZoomedGridSVG to confirm the new overlay labels are generated

## Testing
- npm test --prefix packages/bytebotd

------
https://chatgpt.com/codex/tasks/task_e_68d1c2c736fc8323b77f0a6c65d24af1