### PR TITLE
Add coordinate suspicion heuristics

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
@@ -1,4 +1,7 @@
-import { CoordinateParser } from './coordinate-parser';
+import {
+  CoordinateParser,
+  evaluateCoordinateSuspicion,
+} from './coordinate-parser';
 
 describe('CoordinateParser', () => {
   let parser: CoordinateParser;
@@ -21,5 +24,36 @@ describe('CoordinateParser', () => {
     const { global } = parser.parse(payload);
 
     expect(global).toEqual({ x: 860, y: 660 });
+  });
+
+  it('identifies coordinates aligned to 100 px intersections as suspicious', () => {
+    const parsed = parser.parse('{"global":{"x":200,"y":300}}');
+
+    const suspicion = evaluateCoordinateSuspicion(parsed, {
+      dimensions: { width: 1000, height: 800 },
+    });
+
+    expect(suspicion.suspicious).toBe(true);
+    expect(suspicion.reasons.join(' ')).toContain('100 px');
+  });
+
+  it('identifies coordinates outside the provided bounds as suspicious', () => {
+    const parsed = parser.parse('{"global":{"x":1200,"y":50}}');
+
+    const suspicion = evaluateCoordinateSuspicion(parsed, {
+      dimensions: { width: 800, height: 600 },
+    });
+
+    expect(suspicion.suspicious).toBe(true);
+    expect(suspicion.reasons.join(' ')).toContain('outside the known bounds');
+  });
+
+  it('identifies overly round multiples of 25 px as suspicious', () => {
+    const parsed = parser.parse('{"global":{"x":250,"y":475}}');
+
+    const suspicion = evaluateCoordinateSuspicion(parsed);
+
+    expect(suspicion.suspicious).toBe(true);
+    expect(suspicion.reasons.join(' ')).toContain('25 px');
   });
 });

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
@@ -1,0 +1,85 @@
+import { Calibrator } from './calibrator';
+import { CoordinateTeacher } from './coordinate-teacher';
+import { CoordinateParser } from './coordinate-parser';
+import { UniversalCoordinateRefiner } from './universal-refiner';
+
+describe('UniversalCoordinateRefiner heuristics', () => {
+  const zoomAnswer = JSON.stringify({
+    global: { x: 64, y: 72 },
+    confidence: 0.9,
+    needsZoom: false,
+  });
+
+  const createRefiner = (fullAnswer: string, dimensions: { width: number; height: number }) => {
+    const ai = {
+      askAboutScreenshot: jest
+        .fn()
+        .mockResolvedValueOnce(fullAnswer)
+        .mockResolvedValueOnce(zoomAnswer),
+    } as any;
+
+    const capture = {
+      full: jest.fn().mockResolvedValue({
+        image: 'placeholder',
+        offset: null,
+      }),
+      zoom: jest.fn().mockResolvedValue({
+        image: 'placeholder',
+        offset: null,
+        region: { x: 0, y: 0, width: 200, height: 200 },
+        zoomLevel: 2,
+      }),
+    };
+
+    const refiner = new UniversalCoordinateRefiner(
+      ai,
+      new CoordinateTeacher(),
+      new CoordinateParser(),
+      new Calibrator(),
+      capture,
+    );
+
+    (refiner as any).getDimensions = jest.fn().mockReturnValue(dimensions);
+
+    return { refiner, ai, capture };
+  };
+
+  it.each([
+    {
+      title: 'coordinates land on the 100 px grid intersections',
+      fullAnswer: JSON.stringify({
+        global: { x: 200, y: 300 },
+        confidence: 0.5,
+        needsZoom: false,
+      }),
+      dimensions: { width: 1000, height: 800 },
+    },
+    {
+      title: 'coordinates fall outside the known dimensions',
+      fullAnswer: JSON.stringify({
+        global: { x: 920, y: 50 },
+        confidence: 0.5,
+        needsZoom: false,
+      }),
+      dimensions: { width: 800, height: 600 },
+    },
+    {
+      title: 'coordinates use overly round 25 px multiples',
+      fullAnswer: JSON.stringify({
+        global: { x: 250, y: 475 },
+        confidence: 0.5,
+        needsZoom: false,
+      }),
+      dimensions: { width: 1000, height: 800 },
+    },
+  ])('forces a zoom step when $title', async ({ fullAnswer, dimensions }) => {
+    const { refiner, capture, ai } = createRefiner(fullAnswer, dimensions);
+
+    const result = await refiner.locate('Test button');
+
+    expect(ai.askAboutScreenshot).toHaveBeenCalledTimes(2);
+    expect(capture.zoom).toHaveBeenCalledTimes(1);
+    expect(result.steps.some((step) => step.id === 'zoom-refine')).toBe(true);
+    expect(result.steps[0].response.needsZoom).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add heuristics to the coordinate parser to flag out-of-bounds and overly rounded predictions
- ensure the universal refiner always zooms when a suspicious coordinate is detected and append a reasoning note
- cover the new heuristics with parser and refiner unit tests

## Testing
- npx jest src/coordinate-system/coordinate-parser.spec.ts src/coordinate-system/universal-refiner.spec.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d1c4f0e9148323be8eef3881bcaaa2