### PR TITLE
Prevent screenshot offsets from affecting drift

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
@@ -79,7 +79,7 @@ export class UniversalCoordinateRefiner {
       progressTaskId: options.progress?.taskId,
     });
 
-    this.calibrator.captureOffset(fullScreenshot.offset);
+    this.calibrator.recordTelemetry(fullScreenshot.offset, 'full-screenshot');
     const dimensions = this.getDimensions(fullScreenshot.image);
 
     const fullPrompt = this.teacher.buildFullFramePrompt({
@@ -135,7 +135,7 @@ export class UniversalCoordinateRefiner {
         progressTaskId: options.progress?.taskId,
       });
 
-      this.calibrator.captureOffset(zoomScreenshot.offset);
+      this.calibrator.recordTelemetry(zoomScreenshot.offset, 'zoom-screenshot');
 
       const zoomPrompt = this.teacher.buildZoomPrompt({
         targetDescription,


### PR DESCRIPTION
## Summary
- add a telemetry buffer to the Calibrator so screenshot metadata can be recorded without influencing drift calculations
- switch the universal refiner to log screenshot offsets via telemetry instead of feeding them into captureOffset
- add a regression test that repeats zoom-only cycles and verifies the reported offset remains at zero

## Testing
- npm run build --prefix packages/shared
- npm test -- coordinate-system/universal-refiner.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1c7af96788323bd26612459b5ca1a