### PR TITLE
Handle zoom region fallback center

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
@@ -214,13 +214,23 @@ export class UniversalCoordinateRefiner {
       : 300;
 
     const zoom = parsed.zoom;
+    const region = zoom?.region;
+
+    const regionDerivedCenter = region
+      ? {
+          x: region.x + region.width / 2,
+          y: region.y + region.height / 2,
+        }
+      : null;
+
     const center =
       zoom?.center ??
+      regionDerivedCenter ??
       parsed.global ??
       (dims ? { x: dims.width / 2, y: dims.height / 2 } : { x: 960, y: 540 });
 
-    const width = zoom?.region?.width ?? fallbackWidth;
-    const height = zoom?.region?.height ?? fallbackHeight;
+    const width = region?.width ?? fallbackWidth;
+    const height = region?.height ?? fallbackHeight;
 
     const rect = {
       x: Math.max(0, Math.round(center.x - width / 2)),


### PR DESCRIPTION
## Summary
- derive zoom center from provided region bounds when explicit center is missing
- preserve requested region dimensions before clamping while resolving zoom requests
- cover region-only zoom responses with a dedicated refiner unit test

## Testing
- `npm test -- --runTestsByPath src/coordinate-system/universal-refiner.spec.ts` *(fails: missing @bytebot/shared module declarations in test env)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c90e3c7483239b7a16a3215b41e9