### PR TITLE
Update coordinate prompts to match actual grid overlay

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
@@ -3,7 +3,6 @@ import { Coordinates } from '../agent/smart-click.types';
 export interface FullFramePromptOptions {
   targetDescription: string;
   offsetHint?: Coordinates | null;
-  samplePoint?: Coordinates | null;
 }
 
 export interface ZoomPromptOptions {
@@ -17,11 +16,9 @@ export interface ZoomPromptOptions {
 export class CoordinateTeacher {
   private readonly overlayLegend = [
     '🟩 Overlay legend:',
-    '  • Bright corner labels show (0,0), (width,0), (0,height), (width,height).',
-    '  • Lime rulers hug the top/left edges every 100 px with numeric ticks.',
-    '  • Crosshair lines run every 100 px across the frame to form a lattice.',
-    '  • A cyan "example" dot is pinned at (100,100) with its coordinates annotated.',
-    '  • Reminder banner: global = overlay origin + measured grid delta.',
+    '  • Corner callouts display (0,0), (width,0), (0,height), (width,height).',
+    '  • Lime rulers along the top and left edges tick every grid interval.',
+    '  • Grid lines span the frame every interval to form a square lattice.',
   ].join('\n');
 
   getOverlayLegend(): string {
@@ -42,12 +39,6 @@ export class CoordinateTeacher {
     if (options.offsetHint) {
       parts.push(
         `Calibration: recent offset applied (${options.offsetHint.x}, ${options.offsetHint.y}). Add this drift correction to your calculation if the overlay looks shifted.`,
-      );
-    }
-
-    if (options.samplePoint) {
-      parts.push(
-        `Example: the overlay marks a reference point at (${options.samplePoint.x}, ${options.samplePoint.y}). Use it to verify you understand the scale.`,
       );
     }
 

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
@@ -80,6 +80,13 @@ describe('UniversalCoordinateRefiner heuristics', () => {
 
     const result = await refiner.locate('Test button');
 
+    const prompt = result.steps[0].prompt;
+    expect(prompt).toContain('Corner callouts display');
+    expect(prompt).toContain('Lime rulers along the top and left edges');
+    expect(prompt).toContain('Grid lines span the frame every interval');
+    expect(prompt).not.toContain('example');
+    expect(prompt).not.toContain('Reminder banner');
+
     expect(ai.askAboutScreenshot).toHaveBeenCalledTimes(2);
     expect(capture.zoom).toHaveBeenCalledTimes(1);
     expect(result.steps.some((step) => step.id === 'zoom-refine')).toBe(true);

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
@@ -85,7 +85,6 @@ export class UniversalCoordinateRefiner {
     const fullPrompt = this.teacher.buildFullFramePrompt({
       targetDescription,
       offsetHint: this.calibrator.getCurrentOffset(),
-      samplePoint: { x: 100, y: 100 },
     });
 
     const fullRaw = await this.ai.askAboutScreenshot(


### PR DESCRIPTION
## Summary
- align the coordinate overlay legend with the grid lines, ticks, and corner callouts that are actually rendered
- drop the unused sample-point guidance from the full-frame prompt and stop passing a fake reference
- update the universal refiner unit test expectations to match the refined legend content

## Testing
- npm test -- coordinate-system/universal-refiner.spec.ts *(fails: cannot resolve @bytebot/shared in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cae9d10083239de170dff4831a44