### PR TITLE
Clarify calibration messaging in coordinate prompts

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
@@ -38,7 +38,7 @@ export class CoordinateTeacher {
 
     if (options.offsetHint) {
       parts.push(
-        `Calibration: recent offset applied (${options.offsetHint.x}, ${options.offsetHint.y}). Add this drift correction to your calculation if the overlay looks shifted.`,
+        `Calibration: recent offset observed (${options.offsetHint.x}, ${options.offsetHint.y}). System will compensate by this amount if the overlay looks shifted; report coordinates directly from the grid annotations.`,
       );
     }
 
@@ -68,7 +68,7 @@ export class CoordinateTeacher {
     }
     if (options.offsetHint) {
       parts.push(
-        `Calibration: apply offset (${options.offsetHint.x}, ${options.offsetHint.y}) if the zoom looks shifted relative to the grid origin.`,
+        `Calibration: recent offset observed (${options.offsetHint.x}, ${options.offsetHint.y}). System will compensate by this amount; rely on the overlay labels when reporting coordinates.`,
       );
     }
     parts.push(`Target: "${targetDescription}".`);

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
@@ -84,6 +84,7 @@ describe('UniversalCoordinateRefiner heuristics', () => {
     expect(prompt).toContain('Corner callouts display');
     expect(prompt).toContain('Lime rulers along the top and left edges');
     expect(prompt).toContain('Grid lines span the frame every interval');
+    expect(prompt).toContain('System will compensate');
     expect(prompt).not.toContain('example');
     expect(prompt).not.toContain('Reminder banner');
 


### PR DESCRIPTION
## Summary
- revise calibration messaging in the full-frame and zoom prompts to explain the system compensates for detected offsets
- align the universal refiner heuristic test with the new informational wording

## Testing
- npm test -- --coordinate-system/universal-refiner.spec.ts *(fails: Cannot find module '@bytebot/shared' when running Jest in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cd4a771083239e7c7e2f2c7806f6