### PR TITLE
Improve coordinate parser zoom heuristics

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
@@ -56,4 +56,15 @@ describe('CoordinateParser', () => {
     expect(suspicion.suspicious).toBe(true);
     expect(suspicion.reasons.join(' ')).toContain('25 px');
   });
+
+  it('keeps needsZoom false for explicit negative zoom phrases', () => {
+    expect(parser.parse('No zoom needed near 100, 200').needsZoom).toBe(false);
+    expect(parser.parse('zoom: false at (10, 20)').needsZoom).toBe(false);
+    expect(parser.parse('zoom = 0 around 50x75').needsZoom).toBe(false);
+  });
+
+  it('sets needsZoom true when a positive cue remains', () => {
+    expect(parser.parse('please zoom in on the target').needsZoom).toBe(true);
+    expect(parser.parse('get closer to the subject').needsZoom).toBe(true);
+  });
 });

--- a/packages/bytebot-agent/src/coordinate-system/coordinate-parser.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-parser.ts
@@ -258,8 +258,20 @@ export class CoordinateParser {
       }
     }
 
-    const needsZoom = sanitized.match(/zoom|refine|closer/i);
-    if (needsZoom) {
+    const normalized = sanitized.toLowerCase();
+    const negativeZoomPatterns = [
+      /\bno\s+zoom\b/,
+      /\bzoom\s*(?:=|:)\s*(?:false|0|no)\b/,
+      /\bzoom\s+(?:not\s+needed|not\s+necessary|not\s+required)\b/,
+      /\bwithout\s+zoom\b/,
+    ];
+    const hasNegativeZoomCue = negativeZoomPatterns.some((pattern) =>
+      pattern.test(normalized),
+    );
+
+    if (hasNegativeZoomCue) {
+      result.needsZoom = false;
+    } else if (/(zoom|refine|closer)/i.test(sanitized)) {
       result.needsZoom = true;
     }
 


### PR DESCRIPTION
## Summary
- add fallback heuristics that detect explicit negative zoom cues before marking a response as requiring zoom
- extend coordinate parser specs with plain-text zoom directive cases covering negative and positive phrases

## Testing
- npm test --prefix packages/bytebot-agent -- src/coordinate-system/coordinate-parser.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1ce5b8b98832381b90111c6ef5967