### PR TITLE
Derive zoom crop size from radius

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
@@ -208,6 +208,30 @@ describe('UniversalCoordinateRefiner heuristics', () => {
     );
   });
 
+  it('derives zoom region size from radius when only center is provided', async () => {
+    const radius = 320;
+    const { refiner, capture } = createRefiner(
+      JSON.stringify({
+        global: null,
+        needsZoom: true,
+        zoom: {
+          center: { x: 360, y: 260 },
+          radius,
+        },
+      }),
+      { width: 700, height: 500 },
+    );
+
+    await refiner.locate('Target with radius only');
+
+    expect(capture.zoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        width: radius * 2,
+        height: 500,
+      }),
+    );
+  });
+
   it('clamps calibrated coordinates to the screenshot bounds', async () => {
     const baseGlobal = { x: 1503, y: 917 };
     const fullAnswer = JSON.stringify({

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
@@ -247,8 +247,26 @@ export class UniversalCoordinateRefiner {
       parsed.global ??
       (dims ? { x: dims.width / 2, y: dims.height / 2 } : { x: 960, y: 540 });
 
-    const width = region?.width ?? fallbackWidth;
-    const height = region?.height ?? fallbackHeight;
+    const diameter =
+      typeof zoom?.radius === 'number' ? Math.max(0, zoom.radius * 2) : null;
+
+    let width = region?.width ?? null;
+    let height = region?.height ?? null;
+
+    if (diameter !== null) {
+      if (width === null) {
+        width = dims ? Math.min(diameter, dims.width) : diameter;
+      }
+      if (height === null) {
+        height = dims ? Math.min(diameter, dims.height) : diameter;
+      }
+    }
+
+    width = width ?? fallbackWidth;
+    height = height ?? fallbackHeight;
+
+    width = Math.max(1, width);
+    height = Math.max(1, height);
 
     const rect = {
       x: Math.max(0, Math.round(center.x - width / 2)),


### PR DESCRIPTION
## Summary
- derive zoom capture dimensions from an AI-provided radius when no region size is given, ensuring the crop stays within the screen bounds
- add a unit test covering radius-only zoom guidance to verify the captured region dimensions

## Testing
- npm run build --prefix packages/shared
- npm run test --prefix packages/bytebot-agent -- universal-refiner.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1da3d0c108323b050892f2bd25886