### PR TITLE
Coerce zoom region strings in coordinate parser

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-parser.spec.ts
@@ -26,6 +26,23 @@ describe('CoordinateParser', () => {
     expect(global).toEqual({ x: 860, y: 660 });
   });
 
+  it('normalizes string valued zoom regions', () => {
+    const payload = JSON.stringify({
+      zoom: {
+        region: {
+          x: '10.4',
+          y: '20.6',
+          width: '30.2',
+          height: '40.8',
+        },
+      },
+    });
+
+    const { zoom } = parser.parse(payload);
+
+    expect(zoom?.region).toEqual({ x: 10, y: 21, width: 30, height: 41 });
+  });
+
   it('identifies coordinates aligned to 100 px intersections as suspicious', () => {
     const parsed = parser.parse('{"global":{"x":200,"y":300}}');
 

--- a/packages/bytebot-agent/src/coordinate-system/coordinate-parser.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-parser.ts
@@ -122,30 +122,20 @@ function normalizeRegion(
     return null;
   }
 
-  const x =
-    typeof value.x === 'number'
-      ? value.x
-      : typeof value.left === 'number'
-        ? value.left
-        : null;
-  const y =
-    typeof value.y === 'number'
-      ? value.y
-      : typeof value.top === 'number'
-        ? value.top
-        : null;
-  const width =
-    typeof value.width === 'number'
-      ? value.width
-      : typeof value.w === 'number'
-        ? value.w
-        : null;
-  const height =
-    typeof value.height === 'number'
-      ? value.height
-      : typeof value.h === 'number'
-        ? value.h
-        : null;
+  const coerceFromKeys = (keys: Array<string | number>): number | null => {
+    for (const key of keys) {
+      const candidate = coerceNumber(value[key as keyof typeof value]);
+      if (candidate != null) {
+        return candidate;
+      }
+    }
+    return null;
+  };
+
+  const x = coerceFromKeys(['x', 'X', 'left', 'Left']);
+  const y = coerceFromKeys(['y', 'Y', 'top', 'Top']);
+  const width = coerceFromKeys(['width', 'Width', 'w', 'W']);
+  const height = coerceFromKeys(['height', 'Height', 'h', 'H']);
 
   if (x == null || y == null || width == null || height == null) {
     return null;


### PR DESCRIPTION
## Summary
- coerce zoom region fields with the numeric helper so string values normalize correctly
- add a unit test ensuring string-based zoom regions parse to rounded numbers

## Testing
- npm test -- coordinate-parser

------
https://chatgpt.com/codex/tasks/task_e_68d1dcb520088323aafab86e33c591a3