### PR TITLE
Clamp zoom region to canvas

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
@@ -208,6 +208,29 @@ describe('UniversalCoordinateRefiner heuristics', () => {
     );
   });
 
+  it('trims oversized zoom requests to the screenshot dimensions', async () => {
+    const { refiner, capture } = createRefiner(
+      JSON.stringify({
+        global: null,
+        needsZoom: true,
+        zoom: {
+          center: { x: 320, y: 240 },
+          region: { x: 0, y: 0, width: 1024, height: 768 },
+        },
+      }),
+      { width: 640, height: 480 },
+    );
+
+    await refiner.locate('Oversized region request');
+
+    expect(capture.zoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        width: 640,
+        height: 480,
+      }),
+    );
+  });
+
   it('derives zoom region size from radius when only center is provided', async () => {
     const radius = 320;
     const { refiner, capture } = createRefiner(

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
@@ -268,6 +268,11 @@ export class UniversalCoordinateRefiner {
     width = Math.max(1, width);
     height = Math.max(1, height);
 
+    if (dims) {
+      width = Math.min(width, dims.width);
+      height = Math.min(height, dims.height);
+    }
+
     const rect = {
       x: Math.max(0, Math.round(center.x - width / 2)),
       y: Math.max(0, Math.round(center.y - height / 2)),


### PR DESCRIPTION
## Summary
- clamp zoom region width and height to known screenshot dimensions
- add a regression test that trims oversized zoom requests to fit the canvas

## Testing
- npm test -- universal-refiner

------
https://chatgpt.com/codex/tasks/task_e_68d1dcca08608323a29c22edaea6e534