### PR TITLE
Adjust bytebot-agent build context for Docker build

### DIFF
--- a/docker/docker-compose.proxy.yml
+++ b/docker/docker-compose.proxy.yml
@@ -57,7 +57,7 @@ services:
 
   bytebot-agent:
     build:
-      context: ../packages/
+      context: ..
       dockerfile: bytebot-agent/Dockerfile
     # Use pre-built image
     image: ghcr.io/bytebot-ai/bytebot-agent:edge


### PR DESCRIPTION
## Summary
- point the bytebot-agent docker-compose build context to the repository root so the Dockerfile can access shared packages and configuration

## Testing
- `docker compose -f docker/docker-compose.proxy.yml build bytebot-agent` *(fails in CI environment because docker is unavailable, but this is the intended verification command)*

------
https://chatgpt.com/codex/tasks/task_e_68d1dd6f3b948323834d830467d799df