### PR TITLE
Fix bytebot-agent docker build path

### DIFF
--- a/docker/docker-compose.proxy.yml
+++ b/docker/docker-compose.proxy.yml
@@ -58,7 +58,7 @@ services:
   bytebot-agent:
     build:
       context: ..
-      dockerfile: bytebot-agent/Dockerfile
+      dockerfile: packages/bytebot-agent/Dockerfile
     # Use pre-built image
     image: ghcr.io/bytebot-ai/bytebot-agent:edge
     container_name: bytebot-agent


### PR DESCRIPTION
## Summary
- update the bytebot-agent service in docker/docker-compose.proxy.yml to reference the actual Dockerfile location under packages/bytebot-agent

## Testing
- docker compose -f docker/docker-compose.proxy.yml build bytebot-agent *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e11e7ff4832387458bf18bba6662