### PR TITLE
Clamp universal refiner coordinates to 0-indexed bounds

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.spec.ts
@@ -286,7 +286,7 @@ describe('UniversalCoordinateRefiner heuristics', () => {
 
     expect(capture.zoom).not.toHaveBeenCalled();
     expect(result.baseCoordinates).toEqual(baseGlobal);
-    expect(result.coordinates).toEqual({ x: 1920, y: 1080 });
-    expect(result.appliedOffset).toEqual({ x: 417, y: 163 });
+    expect(result.coordinates).toEqual({ x: 1919, y: 1079 });
+    expect(result.appliedOffset).toEqual({ x: 416, y: 162 });
   });
 });

--- a/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
+++ b/packages/bytebot-agent/src/coordinate-system/universal-refiner.ts
@@ -185,9 +185,11 @@ export class UniversalCoordinateRefiner {
     const adjusted = this.calibrator.apply(bestGlobal);
 
     const bounds = dimensions ?? DEFAULT_CANVAS_DIMENSIONS;
+    const maxX = Math.max(0, bounds.width - 1);
+    const maxY = Math.max(0, bounds.height - 1);
     const clamped = {
-      x: Math.min(bounds.width, Math.max(0, adjusted.x)),
-      y: Math.min(bounds.height, Math.max(0, adjusted.y)),
+      x: Math.min(maxX, Math.max(0, adjusted.x)),
+      y: Math.min(maxY, Math.max(0, adjusted.y)),
     };
 
     let appliedOffset = currentOffset;


### PR DESCRIPTION
## Summary
- clamp universal coordinate refiner outputs to width - 1 / height - 1 while maintaining non-negative bounds
- update clamping test expectations to reflect 0-indexed maxima

## Testing
- npm test (packages/bytebot-agent)


------
https://chatgpt.com/codex/tasks/task_e_68d1e19196ec83239bd4831cb5475789