### PR TITLE
Fix universal coordinate config path resolution

### DIFF
--- a/packages/shared/scripts/copy-universal-coordinate-config.cjs
+++ b/packages/shared/scripts/copy-universal-coordinate-config.cjs
@@ -1,10 +1,11 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const repoConfigPath = path.resolve(
-  __dirname,
-  '../../..',
-  'config/universal-coordinates.yaml',
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const repoConfigPath = path.join(
+  repoRoot,
+  'config',
+  'universal-coordinates.yaml',
 );
 const distConfigDir = path.resolve(__dirname, '..', 'dist', 'config');
 const distConfigPath = path.join(distConfigDir, 'universal-coordinates.yaml');


### PR DESCRIPTION
## Summary
- resolve the universal coordinate config from the repository root before copying it into the shared dist folder

## Testing
- npm run build --prefix packages/shared
- npm run build --prefix packages/bytebot-ui *(fails: `next` binary missing because dependencies cannot be installed in this environment)*
- npm run build --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68d1e2fb36808323a84d8a008f7883a0