### PR TITLE
Update bytebot-agent Dockerfile to preserve packages directory

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -5,11 +5,10 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copy app source
-COPY ./packages/shared ./shared
-COPY ./packages/bytebot-agent/ ./bytebot-agent/
+COPY ./packages ./packages
 COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
 
-WORKDIR /app/bytebot-agent
+WORKDIR /app/packages/bytebot-agent
 
 # Install dependencies
 RUN npm install


### PR DESCRIPTION
## Summary
- copy the entire packages workspace into /app so bytebot-agent build scripts resolve relative paths
- keep universal-coordinates.yaml under /app/config for runtime access

## Testing
- docker compose -f docker/docker-compose.proxy.yml build bytebot-agent *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1eff31844832381fe3734e2b1fa94