### PR TITLE
Adjust bytebot-ui Docker build context

### DIFF
--- a/docker/docker-compose.proxy.yml
+++ b/docker/docker-compose.proxy.yml
@@ -100,8 +100,8 @@ services:
 
   bytebot-ui:
     build:
-      context: ../packages/
-      dockerfile: bytebot-ui/Dockerfile
+      context: ..
+      dockerfile: packages/bytebot-ui/Dockerfile
       args:
         - BYTEBOT_AGENT_BASE_URL=${BYTEBOT_AGENT_BASE_URL:-http://bytebot-agent:9991}
         - BYTEBOT_DESKTOP_VNC_URL=${BYTEBOT_DESKTOP_VNC_URL:-http://bytebot-desktop:9990/websockify}

--- a/packages/bytebot-ui/Dockerfile
+++ b/packages/bytebot-ui/Dockerfile
@@ -13,10 +13,11 @@ ENV BYTEBOT_DESKTOP_VNC_URL=${BYTEBOT_DESKTOP_VNC_URL}
 WORKDIR /app
 
 # Copy app source
-COPY ./shared ./shared
-COPY ./bytebot-ui/ ./bytebot-ui
+COPY packages/shared ./packages/shared
+COPY packages/bytebot-ui/ ./packages/bytebot-ui
+COPY config/universal-coordinates.yaml ./config/universal-coordinates.yaml
 
-WORKDIR /app/bytebot-ui
+WORKDIR /app/packages/bytebot-ui
 
 # Install dependencies
 RUN npm install


### PR DESCRIPTION
## Summary
- update the bytebot-ui service build context so the Docker build can access top-level configuration files
- copy the shared package and universal coordinates config into the UI image before building

## Testing
- docker compose -f docker/docker-compose.proxy.yml build bytebot-ui *(fails: docker client unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f26f029483239138bf7c0b54ac7c