### PR TITLE
Fix bytebot desktop dockerfile path

### DIFF
--- a/docker/docker-compose.proxy.yml
+++ b/docker/docker-compose.proxy.yml
@@ -5,7 +5,7 @@ services:
     # Build from source
     build:
       context: ..
-      dockerfile: bytebotd/Dockerfile
+      dockerfile: packages/bytebotd/Dockerfile
     # Use pre-built image
     image: ghcr.io/bytebot-ai/bytebot-desktop:edge
     shm_size: "2g"


### PR DESCRIPTION
## Summary
- point the bytebot desktop compose build to the packages/bytebotd Dockerfile so the relative path resolves within the repo

## Testing
- docker compose -f docker/docker-compose.proxy.yml up -d --build *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f4a66204832392e1fafa8eae92e7