### PR TITLE
Adjust universal coordinate exports

### DIFF
--- a/packages/bytebotd/src/config/universal-coordinates.config.spec.ts
+++ b/packages/bytebotd/src/config/universal-coordinates.config.spec.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import { resolveConfigPath } from '@bytebot/shared';
+import { resolveConfigPath } from '@bytebot/shared/config/universalCoordinates';
 
 describe('Universal coordinate config discovery', () => {
   const originalOverride = process.env.BYTEBOT_COORDINATE_CONFIG;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,11 @@
     ".": {
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
+    },
+    "./config/universalCoordinates": {
+      "import": "./dist/config/universalCoordinates.js",
+      "require": "./dist/config/universalCoordinates.js",
+      "types": "./dist/config/universalCoordinates.d.ts"
     }
   },
   "devDependencies": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,4 +3,3 @@ export * from "./utils/messageContent.utils";
 export * from "./utils/computerAction.utils";
 export * from "./types/computerAction.types";
 export * from "./constants/agent.constants";
-export * from "./config/universalCoordinates";


### PR DESCRIPTION
## Summary
- remove the universal coordinate config helpers from the default @bytebot/shared surface
- expose the config helpers via a dedicated config/universalCoordinates subpath export for Node consumers
- update the bytebotd universal coordinate config spec to read from the new subpath

## Testing
- npm run build --prefix packages/shared
- npm run build --prefix packages/bytebot-ui *(fails: Next.js binary unavailable because package installation is blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f644737c8323b53978821e2a9139