### PR TITLE
Ensure production start uses compiled bundle

### DIFF
--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -13,7 +13,7 @@
     "start": "npm run build --prefix ../shared && nest start",
     "start:dev": "npm run build --prefix ../shared && nest start --watch",
     "start:debug": "npm run build --prefix ../shared && nest start --debug --watch",
-    "start:prod": "npm run build --prefix ../shared && npx prisma migrate deploy && npx prisma generate && nest build && node dist/main.js",
+    "start:prod": "npm run build && npm run prisma:prod && node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- update the bytebot-agent start:prod script to run the full build before migrations and launching the compiled server

## Testing
- npm run build --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68d1faaca3fc8323a68dcf9dbaf1243c