### PR TITLE
Build bytebot-agent during Docker image creation

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -1,22 +1,20 @@
-# Base image
-FROM node:20-alpine
+# syntax=docker/dockerfile:1
 
-# Create app directory
+FROM node:20-alpine AS base
+
 WORKDIR /app
 
-# Copy app source
 COPY ./packages ./packages
 COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
 
 WORKDIR /app/packages/bytebot-agent
 
-# Install dependencies
 RUN npm install
-
 
 RUN npm run build
 
-# Run the application
-CMD ["npm", "run", "start:prod"] 
+RUN npm prune --omit=dev
+
+CMD ["node", "dist/main.js"]
 
 

--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -13,7 +13,7 @@
     "start": "npm run build --prefix ../shared && nest start",
     "start:dev": "npm run build --prefix ../shared && nest start --watch",
     "start:debug": "npm run build --prefix ../shared && nest start --debug --watch",
-    "start:prod": "npm run build && npm run prisma:prod && node dist/main.js",
+    "start:prod": "npm run prisma:prod && node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- update the bytebot-agent production script to rely on an existing dist bundle
- compile the NestJS service as part of the Docker image build and execute the compiled main file directly

## Testing
- npm run build
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres node dist/main.js *(fails with expected database connection error after Nest boots)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ff3835dc8323942b3c461af136c3