### PR TITLE
Run Prisma migrations before starting agent server

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -15,6 +15,6 @@ RUN npm run build
 
 RUN npm prune --omit=dev
 
-CMD ["node", "dist/main.js"]
+CMD ["sh", "-c", "npm run prisma:prod && node dist/main.js"]
 
 


### PR DESCRIPTION
## Summary
- ensure the bytebot-agent Docker image runs Prisma migrations before starting the compiled server

## Testing
- docker build . (fails: docker not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d200f60ab48323930408efa1469d72