### PR TITLE
Move vision metadata to model info blocks

### DIFF
--- a/docs/deployment/litellm.mdx
+++ b/docs/deployment/litellm.mdx
@@ -138,7 +138,7 @@ graph LR
 
 ### Vision model support
 
-1. **Mark vision-capable backends.** Set `supports_vision: true` under `litellm_params` for any alias that can interpret screenshots or image uploads. The agent surfaces this flag in `/tasks/models`, allowing the UI (and automations such as Smart Focus) to distinguish which models can receive desktop captures.
+1. **Mark vision-capable backends.** Set `supports_vision: true` inside a `model_info` block for any alias that can interpret screenshots or image uploads. The agent surfaces this flag in `/tasks/models`, allowing the UI (and automations such as Smart Focus) to distinguish which models can receive desktop captures.
 2. **Choose the active Smart Focus model.** Point `BYTEBOT_SMART_FOCUS_MODEL` at the LiteLLM alias you want Smart Focus to call. Combined with `BYTEBOT_LLM_PROXY_URL`, this environment variable lets you flip between OpenAI, Anthropic, Gemini, or local multimodal backends without redeploying the agent.
 
 ### Azure OpenAI
@@ -158,6 +158,7 @@ model_list:
       api_base: https://your-resource.openai.azure.com/
       api_key: your-azure-key
       api_version: "2024-02-15-preview"
+    model_info:
       supports_vision: true
 ```
 

--- a/packages/bytebot-agent/src/tasks/tasks.controller.spec.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.spec.ts
@@ -98,6 +98,8 @@ describe('TasksController', () => {
               model_name: 'Proxy GPT',
               litellm_params: {
                 model: 'proxy/gpt-4',
+              },
+              model_info: {
                 supports_vision: true,
               },
             },

--- a/packages/bytebot-agent/src/tasks/tasks.controller.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.ts
@@ -113,6 +113,7 @@ export class TasksController {
         const models: BytebotAgentModel[] = proxyModelList.map((model: any) => {
           const supportsVision =
             model.supports_vision === true ||
+            model.model_info?.supports_vision === true ||
             model.litellm_params?.supports_vision === true ||
             model.litellm_params?.supports_image_input === true;
 

--- a/packages/bytebot-llm-proxy/litellm-config.yaml
+++ b/packages/bytebot-llm-proxy/litellm-config.yaml
@@ -3,16 +3,19 @@ model_list:
     litellm_params:
       model: anthropic/claude-opus-4-20250514
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
       supports_vision: true
   - model_name: claude-sonnet-4
     litellm_params:
       model: anthropic/claude-sonnet-4-20250514
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
       supports_vision: true
   - model_name: gpt-4o
     litellm_params:
       model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
       supports_vision: true
   - model_name: o3-pro
     litellm_params:
@@ -26,11 +29,13 @@ model_list:
     litellm_params:
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
       supports_vision: true
   - model_name: gpt-4.1
     litellm_params:
       model: openai/gpt-4.1
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
       supports_vision: true
   - model_name: gpt-5-thinking
     litellm_params:
@@ -53,32 +58,38 @@ model_list:
       model: vertex_ai/gemini-1.5-pro
       vertex_project: gen-lang-client-0096858366
       vertex_location: us-central1
+    model_info:
       supports_vision: true
   - model_name: gemini-vertex-flash
     litellm_params:
       model: vertex_ai/gemini-1.5-flash
       vertex_project: gen-lang-client-0096858366
       vertex_location: us-central1
+    model_info:
       supports_vision: true
   - model_name: gemini-1.5-pro
     litellm_params:
       model: gemini/gemini-1.5-pro-latest
       api_key: os.environ/GEMINI_API_KEY
+    model_info:
       supports_vision: true
   - model_name: gemini-1.5-flash
     litellm_params:
       model: gemini/gemini-1.5-flash-latest
       api_key: os.environ/GEMINI_API_KEY
+    model_info:
       supports_vision: true
   - model_name: openrouter-claude-3.5-sonnet
     litellm_params:
       model: openrouter/anthropic/claude-3.5-sonnet
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
       supports_vision: true
   - model_name: openrouter-claude-3.7-sonnet
     litellm_params:
       model: openrouter/anthropic/claude-3.7-sonnet
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
       supports_vision: true
   - model_name: openrouter-grok-4-fast-free
     litellm_params:
@@ -88,21 +99,25 @@ model_list:
     litellm_params:
       model: openrouter/google/gemini-2.5-flash
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
       supports_vision: true
   - model_name: openrouter-gemini-2.5-pro
     litellm_params:
       model: openrouter/google/gemini-2.5-pro
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
       supports_vision: true
   - model_name: openrouter-/internvl3-78b
     litellm_params:
       model: openrouter/opengvlab/internvl3-78b
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
       supports_vision: true
   - model_name: openrouter-gemini-1.5-pro
     litellm_params:
       model: openrouter/google/gemini-1.5-pro-latest
       api_key: os.environ/OPENROUTER_API_KEY
+    model_info:
       supports_vision: true
   # Add local models via LMStudio
   - model_name: local-lmstudio-ui-tars-72b-dpo
@@ -123,6 +138,7 @@ model_list:
       api_base: http://192.168.4.250:1234/v1
       api_key: lm-studio
       supports_function_calling: true
+    model_info:
       supports_vision: true
   - model_name: local-lmstudio-ui-tars-7b-dpo
     litellm_params:


### PR DESCRIPTION
## Summary
- move `supports_vision` flags in the LiteLLM proxy config into adjacent `model_info` sections for multimodal aliases
- update the agent's proxy model mapper (and unit test) to recognize `model_info.supports_vision`
- document the new placement for the vision flag so operators avoid nesting it under `litellm_params`

## Testing
- npm test -- tasks/tasks.controller.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d203675cf08323abf30296d406ea82