### PR TITLE
Update bytebotd supervisor command path

### DIFF
--- a/packages/bytebotd/root/etc/supervisor/conf.d/supervisord.conf
+++ b/packages/bytebotd/root/etc/supervisor/conf.d/supervisord.conf
@@ -80,8 +80,8 @@ depends_on=x11vnc
 
 [program:bytebotd]
 user=user
-command=node /bytebot/bytebotd/dist/main.js
-directory=/bytebot/bytebotd
+command=node /bytebot/packages/bytebotd/dist/main.js
+directory=/bytebot/packages/bytebotd
 autostart=true
 autorestart=true
 startsecs=5


### PR DESCRIPTION
## Summary
- update the supervisor configuration for bytebotd to use the monorepo path inside the container

## Testing
- `docker compose -f docker/docker-compose.yml build bytebotd` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d20687f37c8323a61e3960633ce521