### PR TITLE
Update bytebotd supervisor command

### DIFF
--- a/packages/bytebotd/root/etc/supervisor/conf.d/supervisord.conf
+++ b/packages/bytebotd/root/etc/supervisor/conf.d/supervisord.conf
@@ -80,7 +80,7 @@ depends_on=x11vnc
 
 [program:bytebotd]
 user=user
-command=node /bytebot/packages/bytebotd/dist/main.js
+command=/bytebot/packages/bytebotd/dist/main.js
 directory=/bytebot/packages/bytebotd
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- update the bytebotd supervisor entry to invoke the bundled dist executable directly

## Testing
- `docker compose -f docker/docker-compose.yml build bytebot-desktop` *(fails: docker command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d20fcdff348323a0dd5ae9ffe225a4