### PR TITLE
Add universal teaching visuals to grid overlay

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
@@ -14,10 +14,16 @@ export interface ZoomPromptOptions {
 }
 
 export class CoordinateTeacher {
+  /**
+   * The legend must stay in sync with the visuals rendered by
+   * grid-overlay.service.ts so models can rely on what they see, not just text.
+   */
   private readonly overlayLegend = [
     '🟩 Overlay legend:',
-    '  • Corner callouts display (0,0), (width,0), (0,height), (width,height).',
-    '  • Lime rulers along the top and left edges tick every grid interval.',
+    '  • Corner callouts show (0,0), (width,0), (0,height), (width,height) in bold red with a white outline.',
+    '  • Lime rulers mark every 100px along the top (left→right) and left edge (reading downward).',
+    '  • A green bullseye at screen center has an arrow and label “Example: (centerX,centerY)”.',
+    '  • Bottom reminder states “X=horizontal(→), Y=vertical(↓)” to reinforce axis orientation.',
     '  • Grid lines span the frame every interval to form a square lattice.',
   ].join('\n');
 


### PR DESCRIPTION
## Summary
- add universal teaching elements (corner labels, rulers, example arrow, formula) to the grid overlay SVG
- provide drawArrow helper and central applyGridOverlay routine that injects the visual teaching overlay when enabled
- update CoordinateTeacher legend documentation to emphasize parity with rendered visuals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d20d9c2f6c8323872466b53109e76f