### PR TITLE
Guard agent cancel handler

### DIFF
--- a/packages/bytebot-agent/src/agent/agent.processor.spec.ts
+++ b/packages/bytebot-agent/src/agent/agent.processor.spec.ts
@@ -469,4 +469,20 @@ describe('AgentProcessor', () => {
       }
     });
   });
+
+  describe('handleTaskCancel', () => {
+    it('ignores cancel events for other tasks', async () => {
+      const { processor } = createProcessor();
+
+      (processor as any).isProcessing = true;
+      (processor as any).currentTaskId = 'task-1';
+
+      const stopProcessingSpy = jest.spyOn(processor as any, 'stopProcessing');
+
+      await (processor as any).handleTaskCancel({ taskId: 'task-2' });
+
+      expect(stopProcessingSpy).not.toHaveBeenCalled();
+      expect((processor as any).isProcessing).toBe(true);
+    });
+  });
 });

--- a/packages/bytebot-agent/src/agent/agent.processor.ts
+++ b/packages/bytebot-agent/src/agent/agent.processor.ts
@@ -113,6 +113,13 @@ export class AgentProcessor {
   async handleTaskCancel({ taskId }: { taskId: string }) {
     this.logger.log(`Task cancel event received for task ID: ${taskId}`);
 
+    if (this.currentTaskId !== taskId) {
+      this.logger.log(
+        `Ignoring cancel event for task ID: ${taskId} because current task is ${this.currentTaskId}`,
+      );
+      return;
+    }
+
     await this.stopProcessing();
   }
 


### PR DESCRIPTION
## Summary
- add a guard to the task cancel handler so it only stops the current task
- add a regression test covering cancel events for other tasks

## Testing
- `npm test --prefix packages/bytebot-agent` *(fails: missing @bytebot/shared module for unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d21374aaa08323bf7827119f845394