### PR TITLE
Clarify task cancellation log message

### DIFF
--- a/packages/bytebot-agent/src/tasks/tasks.service.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.service.ts
@@ -409,7 +409,7 @@ export class TasksService {
     // Broadcast cancel event so AgentProcessor can cancel processing
     this.eventEmitter.emit('task.cancel', { taskId });
 
-    this.logger.log(`Task ${taskId} cancelled and marked as failed`);
+    this.logger.log(`Task ${taskId} cancelled`);
     this.tasksGateway.emitTaskUpdate(taskId, updatedTask);
 
     return updatedTask;


### PR DESCRIPTION
## Summary
- update the task cancellation log message so it no longer mentions being marked as failed

## Testing
- `npm test --prefix packages/bytebot-agent` *(fails: UniversalCoordinateRefiner heuristics expectations do not match generated prompt text)*

------
https://chatgpt.com/codex/tasks/task_e_68d213945f688323af72a6599017277a