### PR TITLE
Run bytebotd under node in supervisor

### DIFF
--- a/packages/bytebotd/root/etc/supervisor/conf.d/supervisord.conf
+++ b/packages/bytebotd/root/etc/supervisor/conf.d/supervisord.conf
@@ -80,7 +80,7 @@ depends_on=x11vnc
 
 [program:bytebotd]
 user=user
-command=/bytebot/packages/bytebotd/dist/main.js
+command=/usr/bin/node /bytebot/packages/bytebotd/dist/main.js
 directory=/bytebot/packages/bytebotd
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- update the supervisor configuration for the desktop daemon to invoke the compiled bundle via the Node runtime

## Testing
- not run (docker is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d21625c9248323a53cd45fdc638b31