### PR TITLE
Add Smart Focus metadata support to CC click tool

### DIFF
--- a/packages/bytebot-agent-cc/src/agent/agent.computer-use.spec.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.computer-use.spec.ts
@@ -1,0 +1,115 @@
+import type { Logger } from '@nestjs/common';
+
+process.env.BYTEBOT_DESKTOP_BASE_URL = 'http://desktop';
+
+const { handleComputerToolUse } = require('./agent.computer-use') as typeof import('./agent.computer-use');
+
+const TOOL_USE = 'tool_use';
+const TEXT = 'text';
+
+const createLogger = (): Logger =>
+  ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+    verbose: jest.fn(),
+    setContext: jest.fn(),
+  } as unknown as Logger);
+
+describe('performClick helper', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn(async (_url: string, options?: any) => {
+      const body = options?.body
+        ? JSON.parse(options.body as string)
+        : { action: undefined };
+
+      if (body.action === 'click_mouse') {
+        return {
+          ok: true,
+          json: jest.fn().mockResolvedValue(null),
+        } as any;
+      }
+
+      if (body.action === 'screenshot') {
+        return {
+          ok: true,
+          json: jest.fn().mockResolvedValue({ image: 'base64-image' }),
+        } as any;
+      }
+
+      return {
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+      } as any;
+    });
+
+    (global as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends description-only clicks to the desktop service', async () => {
+    const block = {
+      type: TOOL_USE,
+      id: 'tool-1',
+      name: 'computer_click_mouse',
+      input: {
+        button: 'left',
+        clickCount: 1,
+        description: '  Click confirm submit button  ',
+        context: {
+          targetDescription: 'Confirm submit',
+          source: 'manual',
+        },
+      },
+    } as any;
+
+    await handleComputerToolUse(block, createLogger());
+
+    expect(fetchMock).toHaveBeenCalled();
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://desktop/computer-use');
+    expect(options?.method).toBe('POST');
+    const payload = JSON.parse((options?.body as string) ?? '{}');
+    expect(payload).toEqual({
+      action: 'click_mouse',
+      button: 'left',
+      clickCount: 1,
+      description: 'Click confirm submit button',
+      context: {
+        targetDescription: 'Confirm submit',
+        source: 'manual',
+      },
+    });
+  });
+
+  it('rejects clicks without coordinates or a valid description', async () => {
+    const block = {
+      type: TOOL_USE,
+      id: 'tool-2',
+      name: 'computer_click_mouse',
+      input: {
+        button: 'left',
+        clickCount: 1,
+        description: 'submit',
+      },
+    } as any;
+
+    const result = await handleComputerToolUse(block, createLogger());
+    expect(result.is_error).toBe(true);
+    const textContent = result.content.find(
+      (item: any) => item.type === TEXT,
+    );
+    expect(textContent).toBeDefined();
+    expect(textContent?.type).toBe(TEXT);
+    expect((textContent as any).text).toContain(
+      'Click rejected: target description must be between 3 and 6 words.',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/bytebot-agent-cc/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent-cc/src/agent/agent.tools.ts
@@ -67,7 +67,7 @@ export const _traceMouseTool = {
 export const _clickMouseTool = {
   name: 'computer_click_mouse',
   description:
-    'Performs a mouse click at the specified coordinates or current position',
+    'Performs a mouse click. Prefer keyboard navigation/shortcuts first; use clicking as a fallback. When clicking, either provide precise coordinates or include a short target description (e.g., "Submit button") to enable Smart Focus support.',
   input_schema: {
     type: 'object' as const,
     properties: {
@@ -77,12 +77,53 @@ export const _clickMouseTool = {
           'Optional click coordinates (defaults to current position)',
         nullable: true,
       },
+      description: {
+        type: 'string' as const,
+        description:
+          'Short description of the intended target (e.g., "Submit button"). REQUIRED if coordinates are omitted; used by Smart Focus to compute exact coordinates. Keep it 3–6 words. Include optional coarse grid hint like "~X=600,Y=420".',
+        minLength: 1,
+        nullable: true,
+      },
       button: buttonSchema,
       holdKeys: holdKeysSchema,
       clickCount: {
         type: 'integer' as const,
         description: 'Number of clicks to perform (e.g., 2 for double-click)',
         default: 1,
+      },
+      context: {
+        type: 'object' as const,
+        description:
+          'Optional telemetry context including region bounds, zoom level, target description, and click source.',
+        properties: {
+          region: {
+            type: 'object' as const,
+            properties: {
+              x: { type: 'number' as const },
+              y: { type: 'number' as const },
+              width: { type: 'number' as const },
+              height: { type: 'number' as const },
+            },
+            additionalProperties: false,
+            nullable: true,
+          },
+          zoomLevel: {
+            type: 'number' as const,
+            description: 'Zoom factor used when capturing the region',
+            nullable: true,
+          },
+          targetDescription: {
+            type: 'string' as const,
+            description: 'Human-readable description of the intended target',
+            nullable: true,
+          },
+          source: {
+            type: 'string' as const,
+            enum: ['manual', 'smart_focus', 'progressive_zoom', 'binary_search'],
+            description: 'Origin of the click request for telemetry analysis',
+            nullable: true,
+          },
+        },
       },
     },
     required: ['button', 'clickCount'],


### PR DESCRIPTION
## Summary
- add description and context fields to the Claude Code computer_click_mouse schema so tools accept Smart Focus metadata
- add a performClick helper that validates short descriptions before forwarding metadata to the desktop API
- extend clickMouse to include description/context in requests and cover description-only clicks with new tests

## Testing
- npm run build --prefix ../shared
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21e2b68c88323850ef285063d29fe