### PR TITLE
Guard telemetry refresh by session

### DIFF
--- a/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
+++ b/packages/bytebot-ui/src/components/telemetry/TelemetryStatus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { format } from "date-fns";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -69,6 +69,12 @@ export function TelemetryStatus({ className = "" }: Props) {
     [sessions, activeSessionId],
   );
 
+  const activeSessionIdRef = useRef(activeSessionId);
+
+  useEffect(() => {
+    activeSessionIdRef.current = activeSessionId;
+  }, [activeSessionId]);
+
   const selectedSessionValue = useMemo(() => {
     if (!sessions.length) {
       return "";
@@ -112,6 +118,9 @@ export function TelemetryStatus({ className = "" }: Props) {
         return;
       }
       const json = (await res.json()) as TelemetrySummary;
+      if (session !== activeSessionIdRef.current) {
+        return;
+      }
       setData(json);
     } catch (error) {
       void error;


### PR DESCRIPTION
## Summary
- cache the active telemetry session id in a ref so refresh requests know which session they targeted
- ignore telemetry summary responses when the active session changes mid-request to avoid overwriting with stale data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d30a73960c83238bbec1ecbc2264ba