### PR TITLE
Add regional weighting to calibrator

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/calibrator.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/calibrator.spec.ts
@@ -52,4 +52,43 @@ describe('Calibrator', () => {
     });
     expect(offset!.x).toBeLessThan(40);
   });
+
+  it('falls back to the global offset when a region lacks samples', () => {
+    const calibrator = new Calibrator();
+
+    for (let i = 0; i < 6; i += 1) {
+      calibrator.captureOffset({ x: 10, y: -5 }, 'global', { success: true });
+    }
+
+    const fallback = calibrator.getRegionalOffset({ x: 450, y: 180 });
+
+    expect(fallback).toEqual({ x: 10, y: -5 });
+  });
+
+  it('uses the regional offset when enough samples exist', () => {
+    const calibrator = new Calibrator();
+    const regionPredicted = { x: 420, y: 210 };
+
+    for (let i = 0; i < 5; i += 1) {
+      calibrator.captureOffset({ x: 12, y: 12 }, 'global', { success: true });
+    }
+
+    for (let i = 0; i < 5; i += 1) {
+      calibrator.recordCorrection(
+        { x: regionPredicted.x - 6, y: regionPredicted.y + 4 },
+        regionPredicted,
+      );
+    }
+
+    for (let i = 0; i < 5; i += 1) {
+      calibrator.captureOffset({ x: 14, y: 14 }, 'global', { success: true });
+    }
+
+    const globalOffset = calibrator.getCurrentOffset();
+    const regionalOffset = calibrator.getRegionalOffset({ x: 430, y: 205 });
+
+    expect(regionalOffset).toEqual({ x: -6, y: 4 });
+    expect(regionalOffset).not.toEqual(globalOffset);
+    expect(calibrator.apply({ x: 430, y: 205 })).toEqual({ x: 424, y: 209 });
+  });
 });


### PR DESCRIPTION
## Summary
- bucket calibration samples into 200px regional bins and expose a helper to read them
- update correction/success recording and `apply` to leverage the regional offsets with a global fallback
- cover sparse vs. populated regional behavior in the calibrator unit tests

## Testing
- npm test -- calibrator

------
https://chatgpt.com/codex/tasks/task_e_68d312103b1c8323a6c21fa3269ef2dd