### PR TITLE
Add telemetry learning metrics and UI visualizations

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/calibration-metrics.spec.ts
+++ b/packages/bytebot-agent/src/coordinate-system/calibration-metrics.spec.ts
@@ -1,0 +1,76 @@
+import { Calibrator } from './calibrator';
+import { CalibrationMetrics } from './calibration-metrics';
+
+describe('CalibrationMetrics', () => {
+  it('summarises calibration attempts and convergence trend', () => {
+    const calibrator = new Calibrator();
+
+    // Create a mix of successful and unsuccessful samples across regions.
+    for (let i = 0; i < 10; i++) {
+      calibrator.recordCorrection(
+        { x: 100 + i, y: 150 + i },
+        { x: 100, y: 150 },
+        {
+          success: i % 2 === 0,
+          error: i,
+          predicted: { x: 100, y: 150 },
+        },
+      );
+    }
+
+    calibrator.recordSuccess(
+      { x: 800, y: 600 },
+      {
+        success: true,
+        error: 0,
+        predicted: { x: 800, y: 600 },
+      },
+    );
+
+    const metrics = new CalibrationMetrics(calibrator, {
+      trendWindowSize: 6,
+      hotspotLimit: 2,
+      hotspotMinAttempts: 2,
+      improvementThreshold: 0.01,
+    });
+
+    const snapshot = metrics.compute();
+
+    expect(snapshot.totalAttempts).toBeGreaterThanOrEqual(11);
+    expect(snapshot.successRate).toBeGreaterThan(0);
+    expect(snapshot.averageError).toBeGreaterThan(0);
+    expect(snapshot.currentWeightedOffset).not.toBeNull();
+
+    expect(snapshot.convergenceTrend).toMatchObject({
+      direction: expect.any(String),
+      recentAverage: expect.any(Number),
+    });
+
+    expect(snapshot.regionalHotspots.length).toBeGreaterThan(0);
+    const hotspot = snapshot.regionalHotspots[0];
+    expect(hotspot.key).toEqual(expect.any(String));
+    expect(hotspot.attempts).toBeGreaterThan(0);
+    expect(hotspot.averageError).not.toBeNull();
+  });
+
+  it('supports metrics logging lifecycle', () => {
+    jest.useFakeTimers();
+    const calibrator = new Calibrator();
+    calibrator.recordCorrection(
+      { x: 15, y: 20 },
+      { x: 10, y: 10 },
+      { success: false, error: 12, predicted: { x: 10, y: 10 } },
+    );
+
+    const metrics = new CalibrationMetrics(calibrator);
+    const logs: unknown[] = [];
+    const stop = metrics.startMetricsLogging(10, (snapshot) => {
+      logs.push(snapshot);
+    });
+
+    jest.advanceTimersByTime(35);
+    stop();
+    expect(logs.length).toBeGreaterThan(0);
+    jest.useRealTimers();
+  });
+});

--- a/packages/bytebot-agent/src/coordinate-system/calibration-metrics.ts
+++ b/packages/bytebot-agent/src/coordinate-system/calibration-metrics.ts
@@ -1,0 +1,257 @@
+import { Coordinates } from '../agent/smart-click.types';
+import { Calibrator, CalibrationSample } from './calibrator';
+
+export type ConvergenceDirection = 'improving' | 'steady' | 'regressing';
+
+export interface ConvergenceTrendMetrics {
+  direction: ConvergenceDirection;
+  delta: number | null;
+  recentAverage: number | null;
+  previousAverage: number | null;
+}
+
+export interface RegionalHotspotMetrics {
+  key: string;
+  center: Coordinates | null;
+  attempts: number;
+  successRate: number | null;
+  averageError: number | null;
+  weightedOffset: Coordinates | null;
+}
+
+export interface CalibrationLearningMetrics {
+  totalAttempts: number;
+  successRate: number | null;
+  averageError: number | null;
+  currentWeightedOffset: Coordinates | null;
+  convergenceTrend: ConvergenceTrendMetrics;
+  regionalHotspots: RegionalHotspotMetrics[];
+}
+
+type CalibratorLike = Pick<
+  Calibrator,
+  'getHistory' | 'getCurrentOffset' | 'getRegionalBuckets'
+>;
+
+interface CalibrationMetricsOptions {
+  trendWindowSize?: number;
+  hotspotLimit?: number;
+  hotspotMinAttempts?: number;
+  improvementThreshold?: number;
+}
+
+const DEFAULT_OPTIONS: Required<CalibrationMetricsOptions> = {
+  trendWindowSize: 20,
+  hotspotLimit: 4,
+  hotspotMinAttempts: Calibrator.MIN_REGIONAL_SAMPLES,
+  improvementThreshold: 0.05,
+};
+
+interface ErrorStatistics {
+  sum: number;
+  count: number;
+}
+
+interface SuccessStatistics {
+  successes: number;
+  total: number;
+}
+
+type MetricsLogger = (metrics: CalibrationLearningMetrics) => void;
+
+export class CalibrationMetrics {
+  private readonly options: Required<CalibrationMetricsOptions>;
+
+  constructor(
+    private readonly calibrator: CalibratorLike,
+    options: CalibrationMetricsOptions = {},
+  ) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  compute(): CalibrationLearningMetrics {
+    const history = this.calibrator.getHistory();
+    const totalAttempts = history.length;
+    const successStats = this.calculateSuccessRate(history);
+    const averageError = this.calculateAverageError(history);
+    const currentWeightedOffset = this.calibrator.getCurrentOffset();
+    const convergenceTrend = this.calculateConvergenceTrend(history);
+    const regionalHotspots = this.calculateRegionalHotspots();
+
+    return {
+      totalAttempts,
+      successRate: successStats,
+      averageError,
+      currentWeightedOffset,
+      convergenceTrend,
+      regionalHotspots,
+    };
+  }
+
+  startMetricsLogging(
+    intervalMs = 60_000,
+    logger: MetricsLogger = (metrics) => console.log(metrics),
+  ): () => void {
+    const execute = () => {
+      try {
+        logger(this.compute());
+      } catch (error) {
+        // Swallow errors to avoid breaking logging loops. Consumers can wrap logger.
+        void error;
+      }
+    };
+
+    execute();
+    const timer = setInterval(execute, intervalMs);
+    return () => clearInterval(timer);
+  }
+
+  private calculateSuccessRate(history: CalibrationSample[]): number | null {
+    const stats = history.reduce<SuccessStatistics>(
+      (acc, sample) => {
+        if (sample.success === null || sample.success === undefined) {
+          return acc;
+        }
+        return {
+          successes: acc.successes + (sample.success ? 1 : 0),
+          total: acc.total + 1,
+        };
+      },
+      { successes: 0, total: 0 },
+    );
+
+    if (stats.total === 0) {
+      return null;
+    }
+
+    return stats.successes / stats.total;
+  }
+
+  private calculateAverageError(history: CalibrationSample[]): number | null {
+    const stats = history.reduce<ErrorStatistics>(
+      (acc, sample) => {
+        const error = sample.error;
+        if (typeof error !== 'number' || !Number.isFinite(error)) {
+          return acc;
+        }
+        return { sum: acc.sum + Math.abs(error), count: acc.count + 1 };
+      },
+      { sum: 0, count: 0 },
+    );
+
+    if (stats.count === 0) {
+      return null;
+    }
+
+    return stats.sum / stats.count;
+  }
+
+  private calculateConvergenceTrend(
+    history: CalibrationSample[],
+  ): ConvergenceTrendMetrics {
+    const windowSize = Math.max(5, this.options.trendWindowSize);
+    const recentErrors = this.collectErrors(history.slice(-windowSize));
+    const previousErrors = this.collectErrors(
+      history.slice(-windowSize * 2, -windowSize),
+    );
+
+    const recentAverage = this.averageFromStats(recentErrors);
+    const previousAverage = this.averageFromStats(previousErrors);
+
+    if (recentAverage === null || previousAverage === null) {
+      return {
+        direction: 'steady',
+        delta: null,
+        recentAverage,
+        previousAverage,
+      };
+    }
+
+    const delta = recentAverage - previousAverage;
+    const baseline = Math.max(previousAverage, 1);
+    const normalizedDelta = delta / baseline;
+    const threshold = this.options.improvementThreshold;
+
+    let direction: ConvergenceDirection = 'steady';
+    if (normalizedDelta <= -threshold) {
+      direction = 'improving';
+    } else if (normalizedDelta >= threshold) {
+      direction = 'regressing';
+    }
+
+    return {
+      direction,
+      delta,
+      recentAverage,
+      previousAverage,
+    };
+  }
+
+  private calculateRegionalHotspots(): RegionalHotspotMetrics[] {
+    const buckets = this.calibrator.getRegionalBuckets();
+    if (!Array.isArray(buckets) || !buckets.length) {
+      return [];
+    }
+
+    const hotspots = buckets
+      .filter((bucket) => bucket.samples.length >= this.options.hotspotMinAttempts)
+      .map((bucket) => {
+        const samples = bucket.samples;
+        const errorStats = this.collectErrors(samples);
+        const successStats = samples.reduce<SuccessStatistics>(
+          (acc, sample) => {
+            if (sample.success === null || sample.success === undefined) {
+              return acc;
+            }
+            return {
+              successes: acc.successes + (sample.success ? 1 : 0),
+              total: acc.total + 1,
+            };
+          },
+          { successes: 0, total: 0 },
+        );
+
+        return {
+          key: bucket.key,
+          center: bucket.center ?? null,
+          attempts: samples.length,
+          successRate:
+            successStats.total > 0
+              ? successStats.successes / successStats.total
+              : null,
+          averageError: this.averageFromStats(errorStats),
+          weightedOffset: bucket.weightedOffset ?? null,
+        } satisfies RegionalHotspotMetrics;
+      })
+      .sort((a, b) => {
+        const aError = a.averageError ?? 0;
+        const bError = b.averageError ?? 0;
+        if (bError !== aError) {
+          return bError - aError;
+        }
+        return b.attempts - a.attempts;
+      });
+
+    return hotspots.slice(0, this.options.hotspotLimit);
+  }
+
+  private collectErrors(samples: CalibrationSample[]): ErrorStatistics {
+    return samples.reduce<ErrorStatistics>(
+      (acc, sample) => {
+        const error = sample.error;
+        if (typeof error !== 'number' || !Number.isFinite(error)) {
+          return acc;
+        }
+        return { sum: acc.sum + Math.abs(error), count: acc.count + 1 };
+      },
+      { sum: 0, count: 0 },
+    );
+  }
+
+  private averageFromStats(stats: ErrorStatistics): number | null {
+    if (stats.count === 0) {
+      return null;
+    }
+    return stats.sum / stats.count;
+  }
+}

--- a/packages/bytebot-agent/src/coordinate-system/index.ts
+++ b/packages/bytebot-agent/src/coordinate-system/index.ts
@@ -10,6 +10,7 @@ import {
   RecordCorrectionOptions,
   RecordSuccessOptions,
 } from './calibrator';
+import { CalibrationMetrics } from './calibration-metrics';
 import { CoordinateParser } from './coordinate-parser';
 import { CoordinateTeacher } from './coordinate-teacher';
 import {
@@ -34,6 +35,7 @@ export type {
 
 export {
   Calibrator,
+  CalibrationMetrics,
   CoordinateParser,
   CoordinateTeacher,
   UniversalCoordinateRefiner,

--- a/packages/bytebot-ui/src/types/index.ts
+++ b/packages/bytebot-ui/src/types/index.ts
@@ -90,6 +90,31 @@ export interface Task {
   files?: File[];
 }
 
+export interface TelemetryLearningMetricsTrend {
+  direction: 'improving' | 'steady' | 'regressing';
+  delta: number | null;
+  recentAverage: number | null;
+  previousAverage: number | null;
+}
+
+export interface TelemetryRegionalHotspot {
+  key: string;
+  center: { x: number; y: number } | null;
+  attempts: number;
+  successRate: number | null;
+  averageError: number | null;
+  weightedOffset: { x: number; y: number } | null;
+}
+
+export interface TelemetryLearningMetrics {
+  totalAttempts: number;
+  successRate: number | null;
+  averageError: number | null;
+  currentWeightedOffset: { x: number; y: number } | null;
+  convergenceTrend: TelemetryLearningMetricsTrend;
+  regionalHotspots: TelemetryRegionalHotspot[];
+}
+
 export interface TelemetrySummary {
   targetedClicks: number;
   untargetedClicks: number;
@@ -104,6 +129,7 @@ export interface TelemetrySummary {
   postClickDiff?: { count: number; avgDiff: number | null };
   smartClicks?: number; // Successful smart click completions
   progressiveZooms?: number;
+  learningMetrics: TelemetryLearningMetrics;
   sessionStart?: string | null;
   sessionEnd?: string | null;
   sessionDurationMs?: number | null;

--- a/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.spec.ts
@@ -72,6 +72,12 @@ describe('TelemetryController', () => {
       expect(summary.sessionEnd).toBe(timeline.sessionEnd);
       expect(summary.sessionDurationMs).toBe(timeline.sessionDurationMs);
       expect(summary.events).toEqual(timeline.events);
+      expect(summary.learningMetrics).toEqual(
+        expect.objectContaining({
+          totalAttempts: expect.any(Number),
+          regionalHotspots: expect.any(Array),
+        }),
+      );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -124,6 +130,8 @@ describe('TelemetryController', () => {
       expect(summary.smartClicks).toBe(1);
       expect(summary.recentAbsDeltas).toEqual([4]);
       expect(summary.avgAbsDelta).toBe(4);
+      expect(summary.learningMetrics.totalAttempts).toBe(1);
+      expect(summary.learningMetrics.successRate).toBe(1);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/bytebotd/src/telemetry/telemetry.controller.ts
+++ b/packages/bytebotd/src/telemetry/telemetry.controller.ts
@@ -37,6 +37,7 @@ export class TelemetryController {
     postClickDiff?: { count: number; avgDiff: number | null };
     smartClicks?: number;
     progressiveZooms?: number;
+    learningMetrics: LearningMetricsSummary;
     sessionStart: string | null;
     sessionEnd: string | null;
     sessionDurationMs: number | null;
@@ -65,123 +66,190 @@ export class TelemetryController {
       let smartClicks = 0;
       let progressiveZooms = 0;
 
+      let learningMetrics: LearningMetricsSummary = createDefaultLearningMetrics();
       try {
         const content = await fs.readFile(logPath, 'utf8');
         const lines = content.split('\n').filter(Boolean);
 
-        const smartClickCompletionIds = new Set<string>();
+        const entries: ParsedTelemetryEntry[] = [];
         for (const line of lines) {
           try {
             const obj = JSON.parse(line);
-            if (obj.type === 'smart_click_complete') {
-              const taskId =
-                typeof obj.clickTaskId === 'string' ? obj.clickTaskId : undefined;
-              if (taskId) {
-                smartClickCompletionIds.add(taskId);
-              }
-            }
+            const timestamp =
+              typeof obj?.timestamp === 'string' ? obj.timestamp : null;
+            const timestampMs = timestamp ? Date.parse(timestamp) : Number.NaN;
+            entries.push({
+              raw: obj,
+              timestamp,
+              timestampMs: Number.isFinite(timestampMs) ? timestampMs : null,
+            });
           } catch (error) {
             // Ignore malformed telemetry entries in pre-pass
           }
         }
 
-        const countedTaskIds = new Set<string>();
-        for (let i = lines.length - 1; i >= 0; i--) {
-          const line = lines[i];
-          try {
-            const obj = JSON.parse(line);
-            if (app && obj.app && obj.app !== app) {
-              continue;
+        const smartClickCompletionIds = new Set<string>();
+        for (const entry of entries) {
+          const obj = entry.raw;
+          if (obj?.type === 'smart_click_complete') {
+            const taskId =
+              typeof obj.clickTaskId === 'string' ? obj.clickTaskId : undefined;
+            if (taskId) {
+              smartClickCompletionIds.add(taskId);
             }
-            if (obj.type === 'smart_click_complete') {
-              const taskId =
-                typeof obj.clickTaskId === 'string'
-                  ? obj.clickTaskId
-                  : undefined;
-              if (taskId && countedTaskIds.has(taskId)) {
-                continue;
-              }
-              if (taskId) {
-                countedTaskIds.add(taskId);
-              }
-
-              const delta =
-                obj && typeof obj.delta === 'object' ? obj.delta : undefined;
-              if (delta) {
-                const dx = Number(delta.x) || 0;
-                const dy = Number(delta.y) || 0;
-                targeted++;
-                sumDx += dx;
-                sumDy += dy;
-                const providedDistance = Number(obj.distance);
-                const distance = Number.isFinite(providedDistance)
-                  ? providedDistance
-                  : Math.hypot(dx, dy);
-                sumAbs += distance;
-                if (recentAbsDeltas.length < limit) {
-                  recentAbsDeltas.push(distance);
-                }
-              }
-
-              if (obj.success === true) {
-                smartClicks += 1;
-              }
-              continue;
-            }
-
-            if (obj.type === 'untargeted_click') {
-              untargeted++;
-            } else if (obj.target && obj.actual && obj.delta) {
-              const clickTaskId =
-                typeof obj.clickTaskId === 'string'
-                  ? obj.clickTaskId
-                  : undefined;
-              if (clickTaskId && countedTaskIds.has(clickTaskId)) {
-                continue;
-              }
-              if (clickTaskId && smartClickCompletionIds.has(clickTaskId)) {
-                countedTaskIds.add(clickTaskId);
-                continue;
-              }
-              if (clickTaskId) {
-                countedTaskIds.add(clickTaskId);
-              }
-              targeted++;
-              const dx = Number(obj.delta.x) || 0;
-              const dy = Number(obj.delta.y) || 0;
-              sumDx += dx;
-              sumDy += dy;
-              sumAbs += Math.hypot(dx, dy);
-              if (recentAbsDeltas.length < limit) {
-                recentAbsDeltas.push(Math.hypot(dx, dy));
-              }
-            } else if (obj.type === 'retry_click') {
-              retryClicks += Number(obj.attempts) || 1;
-            } else if (obj.type === 'hover_probe') {
-              const d = Number(obj.diff) || 0;
-              hoverCount++;
-              hoverSum += d;
-            } else if (obj.type === 'post_click_diff') {
-              const d = Number(obj.diff) || 0;
-              postCount++;
-              postSum += d;
-            } else if (obj.type === 'action' && obj.name) {
-              actionCounts.set(obj.name, (actionCounts.get(obj.name) || 0) + 1);
-              if (
-                obj.name === 'screenshot_region' ||
-                obj.name === 'screenshot_custom_region'
-              ) {
-                progressiveZooms += 1;
-              }
-            } else if (obj.type === 'progressive_zoom') {
-              progressiveZooms += 1;
-            }
-          } catch (error) {
-            // Ignore malformed telemetry entries in summary parsing
           }
         }
+
+        const countedTaskIds = new Set<string>();
+        const attemptSamples: AttemptSample[] = [];
+        const regionalAttempts = new Map<string, AttemptSample[]>();
+
+        for (const entry of entries) {
+          const obj = entry.raw;
+          if (app && obj?.app && obj.app !== app) {
+            continue;
+          }
+
+          if (obj?.type === 'smart_click_complete') {
+            const taskId =
+              typeof obj.clickTaskId === 'string'
+                ? obj.clickTaskId
+                : undefined;
+            if (taskId && countedTaskIds.has(taskId)) {
+              continue;
+            }
+            if (taskId) {
+              countedTaskIds.add(taskId);
+            }
+
+            const delta = extractDelta(obj);
+            if (delta) {
+              targeted++;
+              sumDx += delta.x;
+              sumDy += delta.y;
+              const distance = extractDistance(obj, delta);
+              sumAbs += distance;
+              attemptSamples.push(
+                createAttemptSample(obj, delta, distance, entry.timestampMs),
+              );
+            }
+
+            if (attemptSamples.length) {
+              const sample = attemptSamples[attemptSamples.length - 1];
+              if (sample.regionKey) {
+                const existing = regionalAttempts.get(sample.regionKey) ?? [];
+                existing.push(sample);
+                regionalAttempts.set(sample.regionKey, existing);
+              }
+            }
+
+            if (recentAbsDeltas.length >= limit) {
+              recentAbsDeltas.shift();
+            }
+            if (attemptSamples.length) {
+              const sample = attemptSamples[attemptSamples.length - 1];
+              if (typeof sample.error === 'number' && Number.isFinite(sample.error)) {
+                recentAbsDeltas.push(sample.error);
+              }
+            }
+
+            if (obj.success === true) {
+              smartClicks += 1;
+            }
+            continue;
+          }
+
+          if (obj?.type === 'untargeted_click') {
+            untargeted++;
+            continue;
+          }
+
+          if (obj?.type === 'retry_click') {
+            retryClicks += Number(obj.attempts) || 1;
+            continue;
+          }
+
+          if (obj?.type === 'hover_probe') {
+            const d = Number(obj.diff) || 0;
+            hoverCount++;
+            hoverSum += d;
+            continue;
+          }
+
+          if (obj?.type === 'post_click_diff') {
+            const d = Number(obj.diff) || 0;
+            postCount++;
+            postSum += d;
+            continue;
+          }
+
+          if (obj?.type === 'action' && obj.name) {
+            actionCounts.set(obj.name, (actionCounts.get(obj.name) || 0) + 1);
+            if (
+              obj.name === 'screenshot_region' ||
+              obj.name === 'screenshot_custom_region'
+            ) {
+              progressiveZooms += 1;
+            }
+            continue;
+          }
+
+          if (obj?.type === 'progressive_zoom') {
+            progressiveZooms += 1;
+            continue;
+          }
+
+          const hasTargetedPayload = obj?.target && obj?.actual && obj?.delta;
+          if (!hasTargetedPayload) {
+            continue;
+          }
+
+          const clickTaskId =
+            typeof obj.clickTaskId === 'string' ? obj.clickTaskId : undefined;
+          if (clickTaskId && countedTaskIds.has(clickTaskId)) {
+            continue;
+          }
+          if (clickTaskId && smartClickCompletionIds.has(clickTaskId)) {
+            continue;
+          }
+          if (clickTaskId) {
+            countedTaskIds.add(clickTaskId);
+          }
+
+          const delta = extractDelta(obj);
+          if (!delta) {
+            continue;
+          }
+
+          targeted++;
+          sumDx += delta.x;
+          sumDy += delta.y;
+          const distance = Math.hypot(delta.x, delta.y);
+          sumAbs += distance;
+
+          const sample = createAttemptSample(
+            obj,
+            delta,
+            distance,
+            entry.timestampMs,
+          );
+          attemptSamples.push(sample);
+          if (sample.regionKey) {
+            const existing = regionalAttempts.get(sample.regionKey) ?? [];
+            existing.push(sample);
+            regionalAttempts.set(sample.regionKey, existing);
+          }
+          if (recentAbsDeltas.length >= limit) {
+            recentAbsDeltas.shift();
+          }
+          if (typeof sample.error === 'number' && Number.isFinite(sample.error)) {
+            recentAbsDeltas.push(sample.error);
+          }
+        }
+
+        learningMetrics = computeLearningMetrics(attemptSamples, regionalAttempts);
       } catch (error) {
-        // Ignore missing or unreadable telemetry log when building summary
+        learningMetrics = createDefaultLearningMetrics();
       }
 
       let calibrationSnapshots = 0;
@@ -213,6 +281,7 @@ export class TelemetryController {
         },
         smartClicks,
         progressiveZooms,
+        learningMetrics,
         sessionStart: timeline.sessionStart,
         sessionEnd: timeline.sessionEnd,
         sessionDurationMs: timeline.sessionDurationMs,
@@ -305,4 +374,339 @@ export class TelemetryController {
     }
     throw error;
   }
+}
+
+type CoordinatesLike = { x: number; y: number };
+
+interface LearningMetricsSummary {
+  totalAttempts: number;
+  successRate: number | null;
+  averageError: number | null;
+  currentWeightedOffset: CoordinatesLike | null;
+  convergenceTrend: {
+    direction: 'improving' | 'steady' | 'regressing';
+    delta: number | null;
+    recentAverage: number | null;
+    previousAverage: number | null;
+  };
+  regionalHotspots: Array<{
+    key: string;
+    center: CoordinatesLike | null;
+    attempts: number;
+    successRate: number | null;
+    averageError: number | null;
+    weightedOffset: CoordinatesLike | null;
+  }>;
+}
+
+interface ParsedTelemetryEntry {
+  raw: Record<string, any>;
+  timestamp: string | null;
+  timestampMs: number | null;
+}
+
+interface AttemptSample {
+  error: number | null;
+  success: boolean | null;
+  timestampMs: number | null;
+  offset: CoordinatesLike | null;
+  regionKey: string | null;
+  regionCenter: CoordinatesLike | null;
+}
+
+const REGION_BUCKET_SIZE = 200;
+const HOTSPOT_LIMIT = 4;
+const HOTSPOT_MIN_ATTEMPTS = 3;
+const TREND_WINDOW = 20;
+const TREND_THRESHOLD = 0.05;
+
+function createDefaultLearningMetrics(): LearningMetricsSummary {
+  return {
+    totalAttempts: 0,
+    successRate: null,
+    averageError: null,
+    currentWeightedOffset: null,
+    convergenceTrend: {
+      direction: 'steady',
+      delta: null,
+      recentAverage: null,
+      previousAverage: null,
+    },
+    regionalHotspots: [],
+  };
+}
+
+function extractDelta(candidate: Record<string, any>): CoordinatesLike | null {
+  const delta = candidate?.delta;
+  if (!delta || typeof delta !== 'object') {
+    return null;
+  }
+  const x = Number(delta.x);
+  const y = Number(delta.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return null;
+  }
+  return { x, y };
+}
+
+function extractDistance(
+  candidate: Record<string, any>,
+  delta: CoordinatesLike,
+): number {
+  const providedDistance = Number(candidate?.distance);
+  if (Number.isFinite(providedDistance) && providedDistance > 0) {
+    return providedDistance;
+  }
+  return Math.hypot(delta.x, delta.y);
+}
+
+function extractCoordinates(candidate: any): CoordinatesLike | null {
+  if (!candidate || typeof candidate !== 'object') {
+    return null;
+  }
+  const x = Number(candidate.x);
+  const y = Number(candidate.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return null;
+  }
+  return { x, y };
+}
+
+function determineRegion(
+  candidate: Record<string, any>,
+): { key: string; center: CoordinatesLike } | null {
+  const source =
+    extractCoordinates(candidate.actual) ??
+    extractCoordinates(candidate.predicted) ??
+    extractCoordinates(candidate.target);
+  if (!source) {
+    return null;
+  }
+  const normalizedX = Math.round(source.x);
+  const normalizedY = Math.round(source.y);
+  if (!Number.isFinite(normalizedX) || !Number.isFinite(normalizedY)) {
+    return null;
+  }
+  const bucketX = Math.floor(normalizedX / REGION_BUCKET_SIZE);
+  const bucketY = Math.floor(normalizedY / REGION_BUCKET_SIZE);
+  const key = `${bucketX},${bucketY}`;
+  const center = {
+    x: bucketX * REGION_BUCKET_SIZE + REGION_BUCKET_SIZE / 2,
+    y: bucketY * REGION_BUCKET_SIZE + REGION_BUCKET_SIZE / 2,
+  } satisfies CoordinatesLike;
+  return { key, center };
+}
+
+function createAttemptSample(
+  candidate: Record<string, any>,
+  delta: CoordinatesLike,
+  distance: number,
+  timestampMs: number | null,
+): AttemptSample {
+  const region = determineRegion(candidate);
+  const success =
+    typeof candidate?.success === 'boolean' ? candidate.success : null;
+  return {
+    error: Number.isFinite(distance) ? distance : null,
+    success,
+    timestampMs: timestampMs ?? null,
+    offset: delta,
+    regionKey: region?.key ?? null,
+    regionCenter: region?.center ?? null,
+  };
+}
+
+function computeLearningMetrics(
+  samples: AttemptSample[],
+  regionalSamples: Map<string, AttemptSample[]>,
+): LearningMetricsSummary {
+  if (!samples.length) {
+    return createDefaultLearningMetrics();
+  }
+
+  const successStats = samples.reduce(
+    (acc, sample) => {
+      if (sample.success === null) {
+        return acc;
+      }
+      return {
+        successes: acc.successes + (sample.success ? 1 : 0),
+        total: acc.total + 1,
+      };
+    },
+    { successes: 0, total: 0 },
+  );
+
+  const errorStats = samples.reduce(
+    (acc, sample) => {
+      if (typeof sample.error !== 'number' || !Number.isFinite(sample.error)) {
+        return acc;
+      }
+      return {
+        sum: acc.sum + Math.abs(sample.error),
+        count: acc.count + 1,
+      };
+    },
+    { sum: 0, count: 0 },
+  );
+
+  const averageError = errorStats.count ? errorStats.sum / errorStats.count : null;
+  const successRate = successStats.total
+    ? successStats.successes / successStats.total
+    : null;
+
+  return {
+    totalAttempts: samples.length,
+    successRate,
+    averageError,
+    currentWeightedOffset: computeWeightedOffsetFromSamples(samples),
+    convergenceTrend: computeConvergenceTrend(samples),
+    regionalHotspots: computeRegionalHotspots(regionalSamples),
+  };
+}
+
+function computeWeightedOffsetFromSamples(
+  samples: AttemptSample[],
+): CoordinatesLike | null {
+  const relevant = samples.filter((sample) => sample.offset !== null);
+  const recentSamples = relevant.slice(-50);
+  if (recentSamples.length < 5) {
+    return null;
+  }
+
+  const aggregate = recentSamples.reduce(
+    (acc, sample, index) => {
+      const offset = sample.offset ?? { x: 0, y: 0 };
+      const age = recentSamples.length - index;
+      const baseWeight = 1 / Math.sqrt(age);
+      const weight =
+        sample.success === true ? baseWeight * 1.5 : baseWeight;
+      return {
+        weighted: {
+          x: acc.weighted.x + offset.x * weight,
+          y: acc.weighted.y + offset.y * weight,
+        },
+        totalWeight: acc.totalWeight + weight,
+      };
+    },
+    { weighted: { x: 0, y: 0 }, totalWeight: 0 },
+  );
+
+  if (aggregate.totalWeight === 0) {
+    return { x: 0, y: 0 };
+  }
+
+  return {
+    x: Math.round(aggregate.weighted.x / aggregate.totalWeight),
+    y: Math.round(aggregate.weighted.y / aggregate.totalWeight),
+  };
+}
+
+function computeConvergenceTrend(
+  samples: AttemptSample[],
+): LearningMetricsSummary['convergenceTrend'] {
+  const windowSize = Math.max(5, Math.min(TREND_WINDOW, samples.length));
+  const errorValues = samples
+    .map((sample) =>
+      typeof sample.error === 'number' && Number.isFinite(sample.error)
+        ? Math.abs(sample.error)
+        : null,
+    )
+    .filter((value): value is number => value !== null);
+
+  const recent = errorValues.slice(-windowSize);
+  const previous = errorValues.slice(-windowSize * 2, -windowSize);
+
+  const recentAverage = recent.length
+    ? recent.reduce((sum, value) => sum + value, 0) / recent.length
+    : null;
+  const previousAverage = previous.length
+    ? previous.reduce((sum, value) => sum + value, 0) / previous.length
+    : null;
+
+  if (recentAverage === null || previousAverage === null) {
+    return {
+      direction: 'steady',
+      delta: null,
+      recentAverage,
+      previousAverage,
+    };
+  }
+
+  const delta = recentAverage - previousAverage;
+  const baseline = Math.max(previousAverage, 1);
+  const normalized = delta / baseline;
+
+  let direction: 'improving' | 'steady' | 'regressing' = 'steady';
+  if (normalized <= -TREND_THRESHOLD) {
+    direction = 'improving';
+  } else if (normalized >= TREND_THRESHOLD) {
+    direction = 'regressing';
+  }
+
+  return { direction, delta, recentAverage, previousAverage };
+}
+
+function computeRegionalHotspots(
+  regionalSamples: Map<string, AttemptSample[]>,
+): LearningMetricsSummary['regionalHotspots'] {
+  const entries = Array.from(regionalSamples.entries()).map(
+    ([key, samples]) => {
+      const successStats = samples.reduce(
+        (acc, sample) => {
+          if (sample.success === null) {
+            return acc;
+          }
+          return {
+            successes: acc.successes + (sample.success ? 1 : 0),
+            total: acc.total + 1,
+          };
+        },
+        { successes: 0, total: 0 },
+      );
+
+      const errorStats = samples.reduce(
+        (acc, sample) => {
+          if (typeof sample.error !== 'number' || !Number.isFinite(sample.error)) {
+            return acc;
+          }
+          return {
+            sum: acc.sum + Math.abs(sample.error),
+            count: acc.count + 1,
+          };
+        },
+        { sum: 0, count: 0 },
+      );
+
+      const averageError = errorStats.count
+        ? errorStats.sum / errorStats.count
+        : null;
+      const successRate = successStats.total
+        ? successStats.successes / successStats.total
+        : null;
+      const weightedOffset = computeWeightedOffsetFromSamples(samples);
+      const regionCenter = samples.find((sample) => sample.regionCenter)?.regionCenter ?? null;
+
+      return {
+        key,
+        center: regionCenter,
+        attempts: samples.length,
+        successRate,
+        averageError,
+        weightedOffset,
+      };
+    },
+  );
+
+  return entries
+    .filter((entry) => entry.attempts >= HOTSPOT_MIN_ATTEMPTS)
+    .sort((a, b) => {
+      const aError = a.averageError ?? 0;
+      const bError = b.averageError ?? 0;
+      if (bError !== aError) {
+        return bError - aError;
+      }
+      return b.attempts - a.attempts;
+    })
+    .slice(0, HOTSPOT_LIMIT);
 }


### PR DESCRIPTION
## Summary
- expose regional calibration buckets and add a reusable CalibrationMetrics helper with coverage
- extend the telemetry summary endpoint with learning metrics analytics sourced from log history
- refresh the telemetry status drawer to surface convergence and hotspot cards backed by the new payload

## Testing
- npm test --prefix packages/bytebot-agent
- npm test --prefix packages/bytebotd *(fails: ts-jest cannot resolve `@bytebot/shared/config/universalCoordinates` even after running the shared build and installing dependencies)*
- npm run lint --prefix packages/bytebot-ui *(fails: `next` binary missing in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3148d97a48323a936447c3043171a