### PR TITLE
Document desktop accuracy drawer metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,23 @@ The fork’s Smart Focus workflow narrows attention in three deliberate passes�
 
 https://github.com/user-attachments/assets/f271282a-27a3-43f3-9b99-b34007fdd169
 
+### Desktop Accuracy Drawer
+
+The `/desktop` dashboard now ships with a Desktop Accuracy drawer that exposes the fork’s adaptive telemetry at a glance. The panel streams live stats for the currently selected session, lets operators jump between historical sessions with the session selector, and provides reset controls so you can zero out a learning run before capturing a new benchmark. Use the reset button to clear the in-memory metrics without restarting the daemon when you want a clean baseline for regression tests or demonstrations.
+
 ![Desktop accuracy overlay](docs/images/hawkeye-desktop.png)
+
+#### Learning Metrics Explained
+
+To help you interpret the drawer’s live readouts, Hawkeye surfaces several learning metrics that highlight how the desktop agent is adapting:
+
+- **Attempt count** — The number of clicks evaluated during the active session. Use it to gauge how large the sample is before trusting the aggregate metrics.
+- **Success rate** — Percentage of attempts that landed within the configured smart click success radius. This reflects real-time precision as the agent iterates on a task.
+- **Weighted offsets** — Average X/Y drift in pixels, weighted by recency so the panel emphasizes the most recent behavior. Watch this to see whether recent tuning is nudging the cursor closer to targets.
+- **Convergence** — A decay-weighted score that trends toward 1.0 as the agent stops overshooting targets, signaling that the current calibration has stabilized.
+- **Hotspots** — Highlighted regions where misses cluster, helping you identify UI zones that need larger affordances, different prompts, or manual overrides.
+
+Together, these metrics give you continuous feedback on how Hawkeye’s coordinate calibration improves over time and whether additional guardrails are necessary for stubborn workflows.
 
 ## Quick Start: Proxy Compose Stack
 


### PR DESCRIPTION
## Summary
- add README subsection that describes the Desktop Accuracy drawer’s live stats, session selector, and reset controls
- document the learning metrics tracked by the drawer so operators can interpret adaptive telemetry
- embed the existing desktop accuracy screenshot alongside the new documentation

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d3249951708323ac8be1608fad706b