### PR TITLE
Clarify zoom overlay instructions

### DIFF
--- a/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
+++ b/packages/bytebot-agent/src/coordinate-system/coordinate-teacher.ts
@@ -72,9 +72,22 @@ export class CoordinateTeacher {
     const { region, zoomLevel, targetDescription } = options;
     const parts: string[] = [];
     parts.push('Precision refinement step.');
-    parts.push(this.overlayLegend);
     parts.push(
       `Zoom metadata: region (${region.x}, ${region.y}, ${region.width}, ${region.height}), zoomLevel=${zoomLevel}. Grid labels remain GLOBAL coordinates.`,
+    );
+    parts.push(
+      [
+        'Zoom overlay guidance:',
+        '  • Cyan grid lines are spaced exactly 25px apart to support precise counting.',
+        '  • Lime rulers along the edges continue to display GLOBAL coordinate labels—read numbers directly from those marks.',
+        '  • Always quote the coordinate values exactly as shown in the visible labels.',
+        '  • Steps:',
+        '      1. Identify the visual target within the zoomed crop.',
+        '      2. Read the nearest lime ruler number for both X and Y axes.',
+        '      3. Count the 25px cyan grid steps from that ruler mark toward the target.',
+        '      4. Add the counted pixels to the ruler label to obtain the precise coordinate.',
+        '      5. Double-check that the final numbers match the global overlay labels before responding.',
+      ].join('\n'),
     );
     if (options.fallbackGlobal) {
       parts.push(


### PR DESCRIPTION
## Summary
- remove the generic overlay legend from the zoom prompt and replace it with explicit instructions
- document the 25px cyan grid spacing, continued global ruler labels, and step-by-step guidance for reading coordinates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d341630cac8323aa2b85b3a5ee45d4