### PR TITLE
Adjust chat input viewport cap for sessions

### DIFF
--- a/packages/bytebot-ui/src/components/messages/ChatContainer.tsx
+++ b/packages/bytebot-ui/src/components/messages/ChatContainer.tsx
@@ -138,6 +138,7 @@ export function ChatContainer({
                     onSend={handleAddMessage}
                     minLines={1}
                     placeholder="Add more details to your task..."
+                    maxViewportRatio={0.25}
                   />
                 </div>
               </div>

--- a/packages/bytebot-ui/src/components/messages/ChatInput.tsx
+++ b/packages/bytebot-ui/src/components/messages/ChatInput.tsx
@@ -21,6 +21,7 @@ interface ChatInputProps {
   onFileUpload?: (files: FileWithBase64[]) => void;
   minLines?: number;
   placeholder?: string;
+  maxViewportRatio?: number;
 }
 
 export function ChatInput({
@@ -31,6 +32,7 @@ export function ChatInput({
   onFileUpload,
   minLines = 1,
   placeholder = "Give Bytebot a task to work on...",
+  maxViewportRatio = 0.4,
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -139,7 +141,7 @@ export function ChatInput({
         return;
       }
 
-      const viewportCap = window.innerHeight * 0.4;
+      const viewportCap = window.innerHeight * maxViewportRatio;
       setResponsiveMaxHeight(
         Math.min(CHAT_INPUT_MAX_PROMPT_HEIGHT, Math.max(viewportCap, 0))
       );
@@ -151,7 +153,7 @@ export function ChatInput({
     return () => {
       window.removeEventListener("resize", updateResponsiveHeight);
     };
-  }, []);
+  }, [maxViewportRatio]);
 
   // Auto-resize textarea based on content
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow ChatInput to accept an optional maxViewportRatio prop so the viewport cap can be tuned per usage
- default the cap to 40% of the viewport and react to prop updates in the responsive height effect
- pass a tighter 25% viewport ratio from ChatContainer during active sessions to avoid stretching the sidebar

## Testing
- `npm run format` *(fails: missing package.json at repository root)*

------
https://chatgpt.com/codex/tasks/task_e_68d37c42be94832380e24dd9796b92fe