### PR TITLE
Clamp in-session chat prompt height

### DIFF
--- a/packages/bytebot-ui/src/components/messages/ChatContainer.tsx
+++ b/packages/bytebot-ui/src/components/messages/ChatContainer.tsx
@@ -138,7 +138,8 @@ export function ChatContainer({
                     onSend={handleAddMessage}
                     minLines={1}
                     placeholder="Add more details to your task..."
-                    maxViewportRatio={0.25}
+                    maxViewportRatio={0.18}
+                    maxHeightPx={180}
                   />
                 </div>
               </div>

--- a/packages/bytebot-ui/src/components/messages/ChatInput.tsx
+++ b/packages/bytebot-ui/src/components/messages/ChatInput.tsx
@@ -22,6 +22,7 @@ interface ChatInputProps {
   minLines?: number;
   placeholder?: string;
   maxViewportRatio?: number;
+  maxHeightPx?: number;
 }
 
 export function ChatInput({
@@ -33,6 +34,7 @@ export function ChatInput({
   minLines = 1,
   placeholder = "Give Bytebot a task to work on...",
   maxViewportRatio = 0.4,
+  maxHeightPx,
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -142,9 +144,16 @@ export function ChatInput({
       }
 
       const viewportCap = window.innerHeight * maxViewportRatio;
-      setResponsiveMaxHeight(
-        Math.min(CHAT_INPUT_MAX_PROMPT_HEIGHT, Math.max(viewportCap, 0))
+      const explicitCap =
+        typeof maxHeightPx === "number" ? Math.max(maxHeightPx, 0) : undefined;
+
+      const resolvedCap = Math.min(
+        CHAT_INPUT_MAX_PROMPT_HEIGHT,
+        Math.max(viewportCap, 0),
+        explicitCap ?? CHAT_INPUT_MAX_PROMPT_HEIGHT
       );
+
+      setResponsiveMaxHeight(Math.max(resolvedCap, 0));
     };
 
     updateResponsiveHeight();
@@ -153,7 +162,7 @@ export function ChatInput({
     return () => {
       window.removeEventListener("resize", updateResponsiveHeight);
     };
-  }, [maxViewportRatio]);
+  }, [maxViewportRatio, maxHeightPx]);
 
   // Auto-resize textarea based on content
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow ChatInput consumers to provide an explicit pixel max-height alongside the viewport ratio
- lower the in-session prompt cap so long prompts scroll internally without obscuring telemetry

## Testing
- npm run lint *(fails: `next` binary unavailable because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37195b16c832390079cc1b75eceae